### PR TITLE
Bug Fix:  Server Error When Newly-Created Users Select an Attorney

### DIFF
--- a/frontend/src/src/components/LandingPage/index.js
+++ b/frontend/src/src/components/LandingPage/index.js
@@ -55,6 +55,7 @@ export default function LandingPage() {
         const profiledata = {
             "attorney" : attorneyKey,
             "organization" : 1,
+            "user_id": attorneyData.filter(attorney => attorney.pk == attorneyKey)[0]["user_id"]
         };
 
         // post to generate profile

--- a/platform/src/expunger/serializers.py
+++ b/platform/src/expunger/serializers.py
@@ -22,13 +22,18 @@ class OrganizationSerializer(serializers.HyperlinkedModelSerializer):
 class AttorneySerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = models.Attorney
-        fields = ["url", "pk", "bar", "name"]
+        fields = ["url", "pk", "bar", "name", "user_id"]
         extra_kwargs = {"url": {"view_name": "expunger:attorney-detail"}}
 
     name = serializers.SerializerMethodField("attorney_name")
 
+    user_id = serializers.SerializerMethodField("user_id")
+
     def attorney_name(self, attorney):
         return f"{attorney.user.first_name} {attorney.user.last_name}"
+    
+    def user_id(serl, attorney):
+        return f"{attorney.user.user_id}"
 
 
 class UserSerializer(serializers.ModelSerializer):

--- a/platform/src/expunger/views.py
+++ b/platform/src/expunger/views.py
@@ -156,7 +156,8 @@ class MyProfileView(APIView):
         """Allow the user to update their profile"""
         profile = getattr(request.user, "expungerprofile", None)
 
-        user = get_object_or_404(User, id=profile.user_id)
+        user_id = profile.user_id if profile is not None else int(request.data.get("user_id"))
+        user = get_object_or_404(User, id=user_id)
 
         updated_user = request.data.get("user")
         if updated_user is not None:


### PR DESCRIPTION
## Overview

After PR #35 was merged, a bug was found when selecting an attorney on the LandingPage ("/") component.  A newly-created users that did not have an expunger profile manually created in the admin page was not able to select an attorney.  Doing so would cause an internal server error.  This was because the "/my-profile" PUT route was getting the user ID from the user's ExpungerProfile object, which would be a "NoneType" object if the profile does not already exist.

This PR fixes the issue by adding the attorney's user id to the attorney data and using that as an alternate way to find the attorney if an expunger profile for the attorney is not found.


### Does this close any currently open issues?

<!-- Change ### to #[number of issue], e.g. #1 -->
Closes #41 

### Testing Instructions

1. Make a new user in the admin page, log in to the react app, and select an attorney that the user will be filing for.  The attorney should be selected and you should be redirected to the "/action" page

3. Go to the "Profile" page and edit the user's info.  The changes should persist and not cause an error.  NOTE, HOWEVER, that if you go to the "Profile" page _before_ selecting an attorney to file for, the profile page will not have any user info.  This is because the GET route the profile page uses assumes the user will already have an expunger profile, and expunger profiles are only created by the PUT route used by the attorney selection function .  I think this is a bigger issue with how the app handles users and profiles and is outside the scope of this bug fix.

4. Run the backend tests in expunger/tests/test_rest.py.  They should all pass.  Many other tests won't pass because the test documents have not yet been added to the repo.


### Before merging

- [x] PR has been reviewed and approved
- [x] All tests should pass, [testing instructions are here](https://github.com/Philadelphia-Lawyers-for-Social-Equity/docket_dashboard#testing).
- [x] Branch has been rebased on `develop` (or the branch being merged to). [See here for rebase instructions](https://github.com/Philadelphia-Lawyers-for-Social-Equity/docket_dashboard/blob/develop/CONTRIBUTING.md#reviewed-work)
