### PR TITLE
limited red hover effect to X buttons

### DIFF
--- a/frontend/src/src/components/GeneratePage/helpers/RemovableCharge.js
+++ b/frontend/src/src/components/GeneratePage/helpers/RemovableCharge.js
@@ -37,8 +37,6 @@ export default function RemovableCharge(props) {
 
     return (
         <div
-            onMouseOver={() => {setHovering(true);}}
-            onMouseOut={() => {setHovering(false);}}
             onFocus={() => {setEditing(true);}}
             onBlur={() => {save();}}
         >
@@ -86,6 +84,8 @@ export default function RemovableCharge(props) {
                 onClick={ props.handleRemove }
                 cursor="pointer"
                 disabled={props.disabled || false}
+                onMouseOver={() => {setHovering(true);}}
+                onMouseOut={() => {setHovering(false);}}
             >
                 X
             </Button>

--- a/frontend/src/src/components/GeneratePage/helpers/RemovableTextField.js
+++ b/frontend/src/src/components/GeneratePage/helpers/RemovableTextField.js
@@ -28,8 +28,6 @@ export default function RemovableTextField(props) {
 
     return(
         <Row
-            onMouseOver={() => setHovering(true)}
-            onMouseOut={() => setHovering(false)}
             className="mb-2"
         >
             <Col sm={2}>
@@ -54,6 +52,8 @@ export default function RemovableTextField(props) {
                 onClick={ props.handleRemove }
                 cursor="pointer"
                 disabled={ props.disabled || false }
+                onMouseOver={() => setHovering(true)}
+                onMouseOut={() => setHovering(false)}
             >
                 X
             </Button>


### PR DESCRIPTION
## Overview

This PR limits the red color change that occurs on the 'X' buttons of certain fields to happen _only_ when the mouse hovers over that button and not the fields or other parts of the form.

https://github.com/user-attachments/assets/f82d2765-eca4-4aad-afe4-c9eb45b1e8b7

### Does this close any currently open issues?

Closes  #31

### Testing Instructions

* Login
* Select Attorney
* Generate Petition from anonymized pdf
* Hover mouse over input fields and compare against hovering over 'X' buttons

### Before merging

- [x] PR has been reviewed and approved
- [ ] All tests should pass, [testing instructions are here](https://github.com/Philadelphia-Lawyers-for-Social-Equity/docket_dashboard#testing).
- [x] Branch has been rebased on `develop` (or the branch being merged to). [See here for rebase instructions](https://github.com/Philadelphia-Lawyers-for-Social-Equity/docket_dashboard/blob/develop/CONTRIBUTING.md#reviewed-work)
