### PR TITLE
Add cancel button to profile edit page

### DIFF
--- a/frontend/src/src/components/ProfilePage/index.js
+++ b/frontend/src/src/components/ProfilePage/index.js
@@ -165,7 +165,7 @@ export default function ProfilePage() {
   return (
     <div className="text-left">
       <Modal.Dialog>
-        <Modal.Header closeButton>
+        <Modal.Header>
           <Modal.Title>Profile Information</Modal.Title>
           <Button id="editbutton" onClick={editProfile}>Edit</Button>
         </Modal.Header>

--- a/frontend/src/src/components/ProfilePage/index.js
+++ b/frontend/src/src/components/ProfilePage/index.js
@@ -28,6 +28,12 @@ export default function ProfilePage() {
   const [isEdit, setIsEdit] = useState(false);
   const { authTokens } = useAuth();
 
+  // Seperate variables for form input values
+  // so that we can revert to original values on cancel
+  const [myFirstNameInput, setMyFirstNameInput] = useState(user.firstName);
+  const [myLastNameInput, setMyLastNameInput] = useState(user.lastName);
+  const [myEmailInput, setMyEmailInput] = useState(user.email);
+
   // useEffect is the React Hook equivalent to ComponentDidMount
   useEffect(() => {
     fetchUserData()
@@ -65,6 +71,10 @@ export default function ProfilePage() {
         setOrgZipcode(res.data.organization.address.zipcode);
         setOrgPhone(res.data.organization.phone);
         setOrgURL(res.data.organization.url);
+        
+        setMyFirstNameInput(res.data.user.first_name);
+        setMyLastNameInput(res.data.user.last_name);
+        setMyEmailInput(res.data.user.email);
       }
     });
   }
@@ -115,9 +125,9 @@ export default function ProfilePage() {
       "attorney": attorneypk,
       "organization": orgpk,
       "user": {
-        "email": myEmail,
-        "first_name": myFirstName,
-        "last_name": myLastName,
+        "email": myEmailInput,
+        "first_name": myFirstNameInput,
+        "last_name": myLastNameInput,
         "username": myUsername
       }
     }
@@ -144,6 +154,14 @@ export default function ProfilePage() {
 
   }
 
+  function handleCancel() {
+    setIsEdit(false);
+    // reset form values to previous input
+    setMyFirstNameInput(myFirstName);
+    setMyLastNameInput(myLastName);
+    setMyEmailInput(myEmail);
+  }
+
   return (
     <div className="text-left">
       <Modal.Dialog>
@@ -167,11 +185,11 @@ export default function ProfilePage() {
             </Col>
             <Col>
               {!isEdit && myFirstName} {!isEdit && myLastName}
-              {isEdit && <input type="text" value={myFirstName} onChange={e => {
-                setMyFirstName(e.target.value);
+              {isEdit && <input type="text" value={myFirstNameInput} onChange={e => {
+                setMyFirstNameInput(e.target.value);
               }} placeholder="First Name" />}
-              {isEdit && <input type="text" value={myLastName} onChange={e => {
-                setMyLastName(e.target.value);
+              {isEdit && <input type="text" value={myLastNameInput} onChange={e => {
+                setMyLastNameInput(e.target.value);
               }} placeholder="Last Name" />}
             </Col>
           </Row>
@@ -181,8 +199,8 @@ export default function ProfilePage() {
             </Col>
             <Col>
               {!isEdit && myEmail}
-              {isEdit && <input type="text" value={myEmail} onChange={e => {
-                setMyEmail(e.target.value);
+              {isEdit && <input type="text" value={myEmailInput} onChange={e => {
+                setMyEmailInput(e.target.value);
               }} placeholder="Email" />}
             </Col>
           </Row>
@@ -211,7 +229,18 @@ export default function ProfilePage() {
         </Modal.Body>
 
         <Modal.Footer>
-          {isEdit && <Button id="submitButton" onClick={postProfile}>Submit</Button>}
+          {isEdit && 
+            <>
+              <Button
+                id="cancelButton"
+                variant="outline-secondary"
+                onClick={handleCancel}
+              >
+                Cancel
+              </Button>
+              <Button id="submitButton" onClick={postProfile}>Submit</Button>
+            </>
+          }
         </Modal.Footer>
 
       </Modal.Dialog>


### PR DESCRIPTION
## Overview

This PR adds a cancel button to the edit profile form on the profile page. Previously there was no cancel button and the only way to exist the edit mode was to submit the form. Now clicking cancel discards any new inputs and brings back the non editing mode of the profile page.

### Does this close any currently open issues?

Closes #48 

### Testing Instructions

- Log in to the app
- Go to profile page
- Click edit and then enter new inputs in the first name, last name, and email fields
- Click submit and make sure the values are updated on the profile page
- Now click edit again and enter new values
- Now click cancel and validate that the original values have not been updated
- Click edit again and validate that the input fields contain the original values and not the new values that were disgarded

### Before merging

- [ ] PR has been reviewed and approved
- [ ] All tests should pass, [testing instructions are here](https://github.com/Philadelphia-Lawyers-for-Social-Equity/docket_dashboard#testing).
- [ ] Branch has been rebased on `develop` (or the branch being merged to). [See here for rebase instructions](https://github.com/Philadelphia-Lawyers-for-Social-Equity/docket_dashboard/blob/develop/CONTRIBUTING.md#reviewed-work)
