### PR TITLE
14 petition preview

### DIFF
--- a/frontend/src/src/components/FileUpload/components/Attorney.js
+++ b/frontend/src/src/components/FileUpload/components/Attorney.js
@@ -1,0 +1,36 @@
+import React from "react";
+import { Card, Col, Row } from 'react-bootstrap';
+
+export default function Attorney(props) {
+    /*
+        props expects:
+        - attorney
+    */
+    const { name, bar } = props.attorney;
+
+    return (
+        <Card className="mb-4">
+            <Card.Header as="h5" className="pl-3">
+                Attorney
+            </Card.Header>
+            <Card.Body>
+                <Row>
+                    <Col sm={2}>
+                        Name
+                    </Col>
+                    <Col sm={8} className="p-0">
+                        {name}
+                    </Col>
+                </Row>
+                <Row>
+                    <Col sm={2}>
+                        Bar Number
+                    </Col>
+                    <Col sm={8}>
+                        <Row>{bar}</Row>
+                    </Col>
+                </Row>
+            </Card.Body>
+        </Card>
+    )
+}

--- a/frontend/src/src/components/FileUpload/components/Organization.js
+++ b/frontend/src/src/components/FileUpload/components/Organization.js
@@ -1,0 +1,42 @@
+import React from "react";
+import { Card, Col, Row } from 'react-bootstrap';
+
+export default function Organization(props) {
+    /*
+        props expects:
+        - organization
+    */
+    const { name, address } = props.organization;
+
+    const orgAddress = address.stree2 
+        ? `${address.street1}, ${address.street2}` 
+        : address.street1;
+
+    return (
+        <Card className="mb-4">
+            <Card.Header as="h5" className="pl-3">
+                Organization
+            </Card.Header>
+            <Card.Body>
+                <Row>
+                    <Col sm={2}>
+                        Name
+                    </Col>
+                    <Col sm={8} className="p-0">
+                        {name}
+                    </Col>
+                </Row>
+                <Row>
+                    <Col sm={2}>
+                        Address
+                    </Col>
+                    <Col sm={8}>
+                        <Row>{orgAddress}</Row>
+                        <Row>{`${address.city}, ${address.state} ${address.zipcode}`}</Row>
+                    </Col>
+                </Row>
+            </Card.Body>
+        </Card>
+    )
+
+}

--- a/frontend/src/src/components/FileUpload/components/PetitionRow.js
+++ b/frontend/src/src/components/FileUpload/components/PetitionRow.js
@@ -107,7 +107,7 @@ export default function PetitionRow(props) {
                 </ul>
             </td>
             <td>
-                Commonwealth of Pennsylvania v. {docket_info.defendant_name ? docket_info.defendant_name : props.name}
+                Commonwealth of Pennsylvania v. {props.name}
             </td>
             <td>
                 <input 

--- a/frontend/src/src/components/FileUpload/components/PetitionRow.js
+++ b/frontend/src/src/components/FileUpload/components/PetitionRow.js
@@ -1,0 +1,122 @@
+import React, { useEffect, useState } from "react";
+import { OverlayTrigger, Tooltip } from 'react-bootstrap';
+import { TbCircleLetterA, TbCircleLetterC, TbCircleLetterS } from "react-icons/tb";
+
+export default function PetitionRow(props) {
+    /* 
+        props expects:
+        - idx
+        - petition
+        - name
+    */
+   const { docket_info, docket_numbers } = props.petition;
+   
+   const [isChecked, setIsChecked] = useState(false);
+
+    const StatusTooltip = ({ children, text}) => {
+        return (
+            <OverlayTrigger
+                overlay={<Tooltip>{text}</Tooltip>}
+            >
+                <div>{children}</div>
+            </OverlayTrigger>
+        )
+    }
+    
+    const alertIcons = () => {
+        const icons = []
+
+        if (props.petition.county && props.petition.county !== "Philadelphia") {
+            icons.push(
+                <StatusTooltip 
+                    key={"county-alert"}
+                    text="This record might include counties other than Philadelphia County."
+                >
+                    <TbCircleLetterC style={{ fontSize: "x-large", color: "red" }} />
+                </StatusTooltip>
+            )
+        }
+
+        if (props.petition.category === "Archived") {
+            icons.push(
+                <StatusTooltip 
+                    key={"archive-alert"}
+                    text="This record is archived"
+                >
+                    <TbCircleLetterA style={{ fontSize: "x-large", color: "orange" }} />
+                </StatusTooltip>
+            )
+        } else if (props.petition.category !== "Docket") {
+            icons.push(
+                <StatusTooltip 
+                    key={"summary-alert"}
+                    text="This record is from a court summary"
+                >
+                    <TbCircleLetterS style={{ fontSize: "x-large", color: "blue" }} />
+                </StatusTooltip>
+            )
+        }
+
+        return icons
+    }
+
+    const petitionNums = () => {
+        const nums = [];
+        if (docket_info.otn) {
+            nums.push(docket_info.otn);
+        }
+        for (const num of docket_numbers) {
+            nums.push(num);
+        };
+        return nums
+    }
+
+    const omitColor = isChecked ? "lightgrey" : "";
+
+    function handleCheckboxChange(e) {
+        if (!isChecked) {
+            props.setDoNotGenerate([
+                ...props.doNotGenerate, 
+                ...petitionNums()
+            ]);
+            props.setOmitCount(props.omitCount + 1);
+        } else {
+            const newOmissions = props.doNotGenerate.filter(num => !petitionNums().includes(num));
+            props.setDoNotGenerate(newOmissions);
+            props.setOmitCount(props.omitCount - 1);
+        }
+        setIsChecked(!isChecked);
+    }
+
+    useEffect(() => {
+        const omitted = petitionNums().filter(num => props.doNotGenerate.includes(num));
+        if (omitted.length > 0) {
+            setIsChecked(true);
+        }
+        // eslint-disable-next-line
+    }, [])
+
+    return (
+        <tr style={{color: omitColor}}>
+            <td>{alertIcons()}</td>
+            <td>{props.idx + 1}</td>
+            <td>{docket_info.otn}</td>
+            <td>
+                <ul style={{ listStyleType: "none", margin: "0", padding: "0" }}>
+                    {docket_numbers.map((num, i) => <li key={i}>{num}</li>)}
+                </ul>
+            </td>
+            <td>
+                Commonwealth of Pennsylvania v. {docket_info.defendant_name ? docket_info.defendant_name : props.name}
+            </td>
+            <td>
+                <input 
+                    type="checkbox"
+                    checked={isChecked}
+                    style={{ accentColor: "grey" }}
+                    onChange={handleCheckboxChange}
+                />
+            </td>
+        </tr>
+    )
+}

--- a/frontend/src/src/components/FileUpload/components/PetitionTable.js
+++ b/frontend/src/src/components/FileUpload/components/PetitionTable.js
@@ -1,0 +1,78 @@
+import React, { useEffect, useState } from "react";
+import {  Card, Table } from 'react-bootstrap';
+
+import { usePetitioner } from "../../../context/petitioner";
+import { initialPetitionState, usePetitions } from "../../../context/petitions";
+import PetitionRow from "./PetitionRow";
+
+export default function PetitionTable(props) {
+    /*
+        props expects:
+        - doNotGenerate
+        - setDoNotGenerate
+        - petitionCount
+    */
+    const { petitioner } = usePetitioner();
+    const { petitions } = usePetitions();
+    const { doNotGenerate, setDoNotGenerate, petitionCount, setPetitionCount} = props;
+    const [omitCount, setOmitCount] = useState(0);
+
+    // table rows for petition preview
+    const petitionList = (petitions !== initialPetitionState) 
+        ? petitions.map((petition, idx) => {
+            return (
+                <PetitionRow 
+                    key={idx} 
+                    idx={idx} 
+                    petition={petition} 
+                    name={petitioner.name} 
+                    doNotGenerate={doNotGenerate}
+                    setDoNotGenerate={setDoNotGenerate}
+                    omitCount={omitCount}
+                    setOmitCount={setOmitCount}
+                />
+            )
+        }) 
+        : null;
+
+    useEffect(() => {
+        if (petitionList) {
+            setPetitionCount(petitionList.length - omitCount);
+        }
+        // eslint-disable-next-line
+    }, [petitionList, omitCount])
+
+    return (
+        <Card className="mb-4">
+            <Card.Header as="h5" className="pl-3">
+                Petitions
+            </Card.Header>
+            <Card.Body className="p-0">
+                <Card.Text className="p-0 pl-3 pt-2 mb-0">
+                    {"Total petitions to generate: " + petitionCount}
+                </Card.Text>
+                <div className="pt-2 ml-2 mr-2">
+                    <Table 
+                        borderless
+                        striped
+                        size="sm"
+                    >
+                        <thead>
+                            <tr>
+                                <th style={{ width: '40px' }}></th>
+                                <th style={{ width: '40px' }}>#</th>
+                                <th style={{ width: '120px' }}>OTN</th>
+                                <th style={{ width: '220px' }}>Docket No.</th>
+                                <th>Case Name</th>
+                                <th style={{ width: '40px' }}>Omit</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {petitionList}
+                        </tbody>
+                    </Table>
+                </div>
+            </Card.Body>
+        </Card>
+    )
+}

--- a/frontend/src/src/components/FileUpload/components/UploadModal.js
+++ b/frontend/src/src/components/FileUpload/components/UploadModal.js
@@ -1,0 +1,141 @@
+import React, { useState } from "react";
+import { Button, Col, Modal } from 'react-bootstrap';
+import axios from 'axios';
+
+import { initialPetitionerState, usePetitioner } from "../../../context/petitioner";
+import { usePetitions } from "../../../context/petitions";
+import { useAuth } from "../../../context/auth";
+
+export default function UploadModal(props) {
+    const { isError, setIsError, show, handleClose } = props
+    const { authTokens } = useAuth();
+    const { petitioner, setPetitioner } = usePetitioner();
+    const { setPetitions, setPetitionNumber } = usePetitions();
+    
+    const [uploadedFiles, setUploadedFiles] = useState([]);
+
+    // list of uploaded files with option to remove file from list
+    const fileNameList = uploadedFiles ? uploadedFiles.map((file, idx) => {
+        return (
+            <li key={file.name}>
+                <span>{file.name}</span>
+                <Button 
+                    variant="danger" 
+                    size="sm"
+                    onClick={() => removeFile(idx)}
+                >
+                    X
+                </Button>
+            </li>
+        )
+    }) : null;
+
+    // Check file type is PDF
+    function checkFileType(file) {
+        if (file.type === "application/pdf") {
+            return file
+        } else {
+            alert("Uploaded documents must be PDF files");
+        }
+    }
+
+    // POST to send PDF files
+    function postDocketParser() {
+
+        // Need to check if a file is chosen
+        if (uploadedFiles === undefined || uploadedFiles.length === 0) {
+            setIsError(true);
+        }
+        else {
+            let pdfdata = new FormData();
+            pdfdata.append('name', 'docket_file');
+            for (let file of uploadedFiles) {
+                pdfdata.append('docket_file', file);
+            }
+
+            let petitionerData = (petitioner !== initialPetitionerState)
+                ? petitioner
+                : null;
+            pdfdata.append('petitioner', JSON.stringify(petitionerData));
+
+            // post to generate profile
+            const url = process.env.REACT_APP_BACKEND_HOST + "/api/v0.2.0/petition/parse-docket/";
+            const token = `Bearer ${authTokens.access}`;
+            var config = {
+                'headers': { 'Authorization': token }
+            };
+
+            axios.post(url, pdfdata, config)
+                .then(res => {
+                    if (res.status === 200) {
+                        console.log("Ready to generate ..!");
+                        console.info(res.data);
+                        setPetitions(res.data.petitions)
+
+                        // If the new petitioner is the same as the previous one, copy as much data as we can from the previous one
+                        if (res.data.petitioner !== null && petitioner !== null && res.data.petitioner.name === petitioner.name) {
+                            let newPetitioner = {};
+                            newPetitioner.name = res.data.petitioner.name;
+                            if (res.data.petitioner.aliases !== null) {
+                                let aliasesSet = new Set(res.data.petitioner.aliases.concat(petitioner.aliases));
+                                newPetitioner.aliases = [...aliasesSet];
+                            } else {
+                                newPetitioner.aliases = petitioner.aliases;
+                            }
+
+                            newPetitioner.dob = res.data.petitioner.dob || petitioner.dob;
+                            newPetitioner.ssn = petitioner.ssn;
+                            newPetitioner.address = petitioner.address;
+                            setPetitioner(newPetitioner);
+                            res.data.petitioner = newPetitioner;
+                        } else {
+                            setPetitioner(res.data.petitioner);
+                        }
+                        
+                        setPetitionNumber(0)
+                        handleClose()
+                    }})
+                .catch(err => {
+                    console.error(err);
+                });
+        }
+    }
+
+    // Add new files
+    function uploadDocs(docs) {
+        const newFiles = Array.from(docs, checkFileType).filter(file => file !== undefined);
+        const newFileNames = new Set(newFiles.map((file) => file.name));
+        const oldUniqueFiles = uploadedFiles.filter((file) => !newFileNames.has(file.name));
+        setUploadedFiles([...oldUniqueFiles, ...newFiles]);
+    }
+
+    function removeFile(idx) {
+        setUploadedFiles(uploadedFiles.filter((_, index) => index !== idx))
+    }
+
+    return (
+        <Modal show={show} onHide={handleClose} >
+            <Modal.Header closeButton >
+                <Modal.Title>Upload Files</Modal.Title>
+            </Modal.Header>
+
+            <Modal.Body>
+                <Col>
+                    <input 
+                        type="file" 
+                        name="docket_file" 
+                        multiple 
+                        accept=".pdf" 
+                        onChange={e => { uploadDocs(e.target.files); }}
+                    />
+                    <ul style={{listStyleType: "none"}}>{fileNameList}</ul>
+                    {isError && <div className="alert alert-warning" role="alert">Please select a file</div>}
+                </Col>
+            </Modal.Body>
+
+            <Modal.Footer>
+                <Button id="fileButton" onClick={postDocketParser}>Submit</Button>
+            </Modal.Footer>
+        </Modal>
+    )
+}

--- a/frontend/src/src/components/FileUpload/index.js
+++ b/frontend/src/src/components/FileUpload/index.js
@@ -1,126 +1,111 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
-import axios from 'axios';
-import { Button, Modal, Col } from 'react-bootstrap';
-import { useAuth } from "../../context/auth";
-import { usePetitions } from '../../context/petitions';
+// import axios from 'axios';
+import { Alert, Button, Card, Container } from 'react-bootstrap';
+
 import { usePetitioner } from '../../context/petitioner';
+import { initialPetitionState, usePetitions } from '../../context/petitions';
+import { useUser } from '../../context/user';
+import Attorney from './components/Attorney';
+import Petitioner from '../GeneratePage/components/Petitioner';
+import PetitionTable from './components/PetitionTable';
+import Organization from './components/Organization';
+import UploadModal from './components/UploadModal';
 
 export default function FileUpload(props) {
     const history = useHistory();
-
-    const [uploadedFiles, setUploadedFiles] = useState([]);
-    const [fileNames, setFileNames] = useState([]);
-    const [isError, setIsError] = useState(false);
-    const { authTokens } = useAuth();
-    const { petitioner, setPetitioner } = usePetitioner();
-    const { setPetitions, setPetitionNumber } = usePetitions();
+    const { user } = useUser();
+    const { petitioner } = usePetitioner();
+    const { petitions, setPetitions } = usePetitions();
     
-    const fileNameList = fileNames.map(name => {
-        return <li key={name}>{name}</li>
-    })
+    const [doNotGenerate, setDoNotGenerate] = useState([]);
+    const [isError, setIsError] = useState(false);
+    const [show, setShow] = useState(false);
+    const [petitionCount, setPetitionCount] = useState(0);
 
-    // On click for the cancel button
-    function returnToChooseAction() {
-        history.push("/");
-    }
+    const handleClose = () => setShow(false);
+    const handleShow = () => setShow(true);
 
-    // On change for getting files
-    function getFile(uploadedDocs) {
-        setFileNames([])
-        for(const file of uploadedDocs) {
-            setUploadedFiles(files => [...files, file]);
-            if (uploadedDocs.length > 1) {
-                setFileNames(nameList => [...nameList, file.name])
+
+    function continuePetitionGeneration() {
+        // remove petitions from array if user has selected to omit them
+        const petitionsToGenerate = petitions.filter(petition => {
+            if (petition.docket_info.otn && doNotGenerate.includes(petition.docket_info.otn)) {
+                return false
             }
-        }
-    }
-
-    // POST to send PDF file
-    function chooseFile() {
-
-
-        // Need to check if a file is chosen
-        if (uploadedFiles === undefined || uploadedFiles.length === 0) {
-            setIsError(true);
-        }
-        else {
-            let pdfdata = new FormData();
-            pdfdata.append('name', 'docket_file');
-            for (let file of uploadedFiles) {
-                pdfdata.append('docket_file', file);
+            for (const num of petition.docket_numbers) {
+                if (doNotGenerate.includes(num)) {
+                    return false
+                }
             }
-
-            // post to generate profile
-            const url = process.env.REACT_APP_BACKEND_HOST + "/api/v0.2.0/petition/parse-docket/";
-            const token = `Bearer ${authTokens.access}`;
-            var config = {
-                'headers': { 'Authorization': token }
-            };
-
-            axios.post(url, pdfdata, config)
-                .then(res => {
-                    if (res.status === 200) {
-                        console.log("Ready to generate ..!");
-                        console.info(res.data);
-                        setPetitions(res.data.petitions)
-
-                        // If the new petitioner is the same as the previous one, copy as much data as we can from the previous one
-                        if (res.data.petitioner !== null && petitioner !== null && res.data.petitioner.name === petitioner.name) {
-                            let newPetitioner = {};
-                            newPetitioner.name = res.data.petitioner.name;
-                            if (res.data.petitioner.aliases !== null) {
-                                let aliasesSet = new Set(res.data.petitioner.aliases.concat(petitioner.aliases));
-                                newPetitioner.aliases = [...aliasesSet];
-                            } else {
-                                newPetitioner.aliases = petitioner.aliases;
-                            }
-
-                            newPetitioner.dob = res.data.petitioner.dob || petitioner.dob;
-                            newPetitioner.ssn = petitioner.ssn;
-                            newPetitioner.address = petitioner.address;
-                            setPetitioner(newPetitioner);
-                            res.data.petitioner = newPetitioner;
-                        } else {
-                            setPetitioner(res.data.petitioner);
-                        }
-                        
-                        setPetitionNumber(0)
-                        history.push("/generate", {"petitionFields": res.data});
-                    }})
-                .catch(err => {
-                    console.error(err);
-                });
-        }
+            return true
+        })
+        setPetitions(petitionsToGenerate)
+        history.push("/generate", {"petitionFields": {petitions: petitionsToGenerate, petitioner}});
     }
+
+    // show upload modal when page first loads and/or no petitions have been uploaded
+    useEffect(() => {
+        if (petitions === initialPetitionState) {
+            handleShow()
+        }
+        // eslint-disable-next-line
+    }, [])
 
     return (
-        <div className="text-center">
-            <Modal.Dialog>
-                <Modal.Header>
-                    <Modal.Title>Upload File</Modal.Title>
-                </Modal.Header>
+        <div>
+            <Container fluid className="pt-4">
+                <div className="d-flex justify-content-between mb-4">
+                    <h4>Petition Generation Preview</h4>
+                    <div >
+                        <Button 
+                            className="mr-2 d-inline"
+                            onClick={handleShow}
+                        >
+                            Upload Files
+                        </Button>
+                        <Button
+                            className="mr-2 d-inline"
+                            onClick={continuePetitionGeneration}
+                            disabled={petitionCount < 1}
+                        >
+                            Continue to Petition Generation
+                        </Button>
+                    </div>
+                </div>
 
-                <Modal.Body>
-                    <Col>
-                        <input 
-                            type="file" 
-                            name="docket_file" 
-                            multiple 
-                            accept=".pdf" 
-                            onChange={e => { getFile(e.target.files); }}
-                        />
-                        <ul style={{listStyleType: "none"}}>{fileNameList}</ul>
-                        {isError && <div className="alert alert-warning" role="alert">Please select a file</div>}
-                    </Col>
-                </Modal.Body>
+                {(petitions === initialPetitionState) && <Alert
+                    variant="warning"
+                    className="justify-content-md-center text-center mb-4"
+                >
+                    Upload a Court Docket or Court Summary to begin petition generation.
+                </Alert>}
 
-                <Modal.Footer>
-                    <Button id="returnToLoginButton" variant="outline-secondary" onClick={returnToChooseAction}>Cancel</Button>
-                    <Button id="fileButton" onClick={chooseFile}>Submit</Button>
-                </Modal.Footer>
-            </Modal.Dialog>
+                <Organization organization={user.organization}/>
 
+                <Attorney attorney={user.attorney}/>
+
+                <Card className="mb-4">
+                    <Card.Header as="h5" className="pl-3">
+                        Petitioner
+                    </Card.Header>
+                    <Petitioner {...petitioner} preview={true}/>
+                </Card>
+
+                <PetitionTable 
+                    doNotGenerate={doNotGenerate}
+                    setDoNotGenerate={setDoNotGenerate}
+                    petitionCount={petitionCount}
+                    setPetitionCount={setPetitionCount}
+                />
+            </Container>
+
+            <UploadModal 
+                isError={isError}
+                handleClose={handleClose}
+                show={show}
+                setIsError={setIsError}
+            />
         </div >
     );
 }

--- a/frontend/src/src/components/GeneratePage/components/Petitioner.js
+++ b/frontend/src/src/components/GeneratePage/components/Petitioner.js
@@ -40,9 +40,18 @@ export default function Petitioner(props) {
         setPetitioner({...petitioner, [attribute]: item[attribute]});
     }
 
+    function showLabel() {
+            if (props.preview) {
+                return <></>;
+            } else {
+                return <h2>{props.label}</h2>;
+            }
+        }
+
     return(
         <>
-            <h2>Petitioner</h2>
+            {showLabel()}
+
             <GeneratorInput
                 label="Full Name"
                 type="text"
@@ -52,6 +61,7 @@ export default function Petitioner(props) {
                 handleChange={handleChange}
                 required={true}
                 disabled={props.disabled || false}
+                previewComponent={props.preview}
             />
 
             <GeneratorInput
@@ -62,6 +72,7 @@ export default function Petitioner(props) {
                 handleChange={handleChange}
                 required={true}
                 disabled={props.disabled || false}
+                previewComponent={props.preview}
             />
 
             <SocialSecurityInput
@@ -73,6 +84,7 @@ export default function Petitioner(props) {
                 handleChange={handleChange}
                 required={true}
                 disabled={props.disabled || false}
+                previewComponent={props.preview}
             />
 
             <EditableList
@@ -83,9 +95,16 @@ export default function Petitioner(props) {
                 handleChange={(e) => {saveAliases(e)}}
                 disabled={props.disabled || false}
                 smallHeader={true}
+                previewComponent={props.preview}
             />
 
-            <Address {...petitioner.address} handleChange={(a) => {handleChange({"address": a});}} disabled={props.disabled || false} />
+            <Address 
+                {...petitioner.address} handleChange={(a) => {
+                    handleChange({"address": a});
+                }} 
+                disabled={props.disabled || false} 
+                previewComponent={props.preview}
+            />
         </>
         );
 }

--- a/frontend/src/src/components/GeneratePage/components/SocialSecurityInput.js
+++ b/frontend/src/src/components/GeneratePage/components/SocialSecurityInput.js
@@ -18,7 +18,7 @@ class SocialSecurityInput extends Component {
   }
 
   render() {
-    const { label, type, placeholder, name, value, required, disabled } = this.props;
+    const { label, type, placeholder, name, value, required, disabled, previewComponent } = this.props;
     const formattedSSN = this.formatSSN(value);
     return (
       <GeneratorInput
@@ -31,6 +31,7 @@ class SocialSecurityInput extends Component {
         required={required}
         maxLength={5}
         disabled={disabled}
+        previewComponent={previewComponent}
       />
     );
   }

--- a/frontend/src/src/components/GeneratePage/helpers/Address.js
+++ b/frontend/src/src/components/GeneratePage/helpers/Address.js
@@ -29,6 +29,7 @@ export default function Address(props) {
             value={props.street1 || ""}
             handleChange={handleChange}
             disabled={props.disabled || false}
+            previewComponent={props.previewComponent}
         />
 
         <GeneratorInput
@@ -38,9 +39,13 @@ export default function Address(props) {
             value={props.street2 || ""}
             handleChange={handleChange}
             disabled={props.disabled || false}
+            previewComponent={props.previewComponent}
         />
 
-        <Form.Group as={Row}>
+        <Form.Group 
+            as={Row}
+            className={props.previewComponent ? "p-0 pl-3 pt-2" : ""}
+        >
             <Col sm={2}/>
             <Col sm={4}>
                 <Form.Control placeholder="City" value={props.city || ""} onChange={e => {

--- a/frontend/src/src/components/GeneratePage/helpers/EditableList.js
+++ b/frontend/src/src/components/GeneratePage/helpers/EditableList.js
@@ -73,7 +73,10 @@ export default function EditableList(props) {
     }
 
     return (
-        <Form.Group as="div">
+        <Form.Group 
+            as="div" 
+            className={props.previewComponent ? "p-0 pl-3 pt-2 mb-0" : ""}
+        >
             {showLabel()}
             {props.items.map((innerProps, idx) => {
                 return (

--- a/frontend/src/src/components/GeneratePage/helpers/GeneratorInput.js
+++ b/frontend/src/src/components/GeneratePage/helpers/GeneratorInput.js
@@ -21,7 +21,10 @@ export default function GeneratorInput(props) {
     let keyName = props.name;
 
     return (
-        <Form.Group as={Row}>
+        <Form.Group 
+            as={Row} 
+            className={props.previewComponent ? "p-0 pl-3 pt-2 mb-0" : ""}
+        >
             <Col sm={2}>
                 <Form.Label>{props.label}</Form.Label>
             </Col>

--- a/frontend/src/src/components/GeneratePage/index.js
+++ b/frontend/src/src/components/GeneratePage/index.js
@@ -9,6 +9,7 @@ import Charges from "./components/Charges";
 import Fines from "./components/Fines";
 import Progress from "./components/Progress";
 import { useAuth } from "../../context/auth";
+import { useUser } from '../../context/user';
 import { initialPetitionState, usePetitions } from "../../context/petitions";
 import { usePetitioner, initialPetitionerState } from "../../context/petitioner";
 
@@ -31,6 +32,7 @@ export default function GeneratePage(props) {
     */
     const history = useHistory();
     const { authTokens } = useAuth();
+    const { user } = useUser();
     const { petitioner, setPetitioner } = usePetitioner();
     const { petitions, setPetitions, petitionNumber, setPetitionNumber } = usePetitions();
     const [success, setSuccess] = useState(false);
@@ -67,6 +69,8 @@ export default function GeneratePage(props) {
             dockets: petitions[petitionNumber].docket_numbers,
             charges: petitions[petitionNumber].charges,
             fines: petitions[petitionNumber].fines,
+            organization: user.organization,
+            attorney: user.attorney,
         };
 
         if (!petitionFields.petition.ratio) {

--- a/frontend/src/src/components/ReviewPage/index.js
+++ b/frontend/src/src/components/ReviewPage/index.js
@@ -5,6 +5,7 @@ import { saveAs } from "file-saver";
 import { Button, Card, Container, ListGroup } from 'react-bootstrap';
 import PetitionSummary from "./components/PetitionSummary";
 import { useAuth } from "../../context/auth";
+import { useUser } from '../../context/user';
 import { initialPetitionerState, usePetitioner } from "../../context/petitioner";
 import { initialPetitionState, usePetitions } from "../../context/petitions";
 import "./style.css";
@@ -34,6 +35,7 @@ const initialSummary = {
 
 export default function ReviewPage(props) {
     const { authTokens } = useAuth();
+    const { user } = useUser();
     const { petitioner, setPetitioner } = usePetitioner();
     const { petitions, setPetitions } = usePetitions();
     const [ summary, setSummary ] = useState(initialSummary);
@@ -86,6 +88,8 @@ export default function ReviewPage(props) {
             dockets: petition.docket_numbers,
             charges: petition.charges,
             fines: petition.fines,
+            organization: user.organization,
+            attorney: user.attorney,
         };
     
         if (!petitionFields.petition.ratio) {

--- a/frontend/src/src/components/nav.js
+++ b/frontend/src/src/components/nav.js
@@ -3,13 +3,16 @@ import { Link } from 'react-router-dom';
 import { Navbar, Nav } from 'react-bootstrap';
 import { useAuth } from '../context/auth';
 import { usePetitioner, initialPetitionerState } from '../context/petitioner';
+import { usePetitions, initialPetitionState } from '../context/petitions';
 
 const Navigation = () => {
   const { logout, authTokens } = useAuth();
   const { setPetitioner } = usePetitioner();
+  const { setPetitions } = usePetitions();
 
   const logOutAndReset = () => {
     setPetitioner(initialPetitionerState);
+    setPetitions(initialPetitionState);
     logout();
   }
 

--- a/frontend/src/src/context/user.js
+++ b/frontend/src/src/context/user.js
@@ -1,4 +1,30 @@
-import React, { createContext, useContext, useState } from 'react';
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import axios from 'axios';
+
+import { useAuth } from './auth';
+
+const initialUserState = {
+  user: {
+    email: "",
+    first_name: "",
+    last_name: "",
+    username: "",
+  },
+  organization: {
+    name: "",
+    address: {},
+    phone: "",
+    pk: -1,
+    url: "",
+  },
+  attorney: {
+    bar: "",
+    name: "",
+    pk: -1,
+    url: "",
+    user_id: -1,
+  }
+}
 
 export const UserContext = createContext();
 
@@ -7,9 +33,29 @@ export function useUser() {
 }
 
 export function UserProvider({ children }) {
-  const [user, setUser] = useState({});
+  const { authTokens } = useAuth();
+  const [user, setUser] = useState(initialUserState);
 
   const value = { user, setUser };
+
+  useEffect(() => {
+    function fetchUserData() {
+        const token = `Bearer ${authTokens.access}`;
+        var config = {
+          headers: { Authorization: token },
+        };
+    
+        // Get to return user data
+        const url =
+          process.env.REACT_APP_BACKEND_HOST + "/api/v0.2.0/expunger/my-profile/";
+        axios.get(url, config).then((res) => {
+          if (res.status === 200) {
+            setUser(res.data);
+          }
+        })
+    }
+    if (authTokens) fetchUserData();
+  }, [authTokens])
 
   return (
     <UserContext.Provider value={value}>

--- a/platform/src/expunger/models.py
+++ b/platform/src/expunger/models.py
@@ -31,6 +31,14 @@ class Organization(models.Model):
 
     def __str__(self):
         return self.name
+    
+    @staticmethod
+    def from_dict(data):
+        return Organization(
+            name=data["name"],
+            phone=data["phone"],
+            address_id=data["address"]["pk"],
+        )
 
 
 class Attorney(models.Model):
@@ -44,6 +52,13 @@ class Attorney(models.Model):
 
     def __str__(self):
         return f"{self.user.first_name} {self.user.last_name}"
+    
+    @staticmethod
+    def from_dict(data):
+        return Attorney(
+            user_id=data["user_id"],
+            bar=data["bar"],
+        )
 
 
 class ExpungerProfile(models.Model):

--- a/platform/src/petition/factories.py
+++ b/platform/src/petition/factories.py
@@ -46,7 +46,6 @@ class PetitionFactory(factory.Factory):
     ratio = factory.fuzzy.FuzzyChoice(PetitionRatio)
     otn = factory.fuzzy.FuzzyInteger(1000000, 9999999)
     judge = factory.Faker("name")
-    defendant_name = factory.Faker("name")
 
 
 class FinesFactory(factory.Factory):

--- a/platform/src/petition/factories.py
+++ b/platform/src/petition/factories.py
@@ -46,6 +46,7 @@ class PetitionFactory(factory.Factory):
     ratio = factory.fuzzy.FuzzyChoice(PetitionRatio)
     otn = factory.fuzzy.FuzzyInteger(1000000, 9999999)
     judge = factory.Faker("name")
+    defendant_name = factory.Faker("name")
 
 
 class FinesFactory(factory.Factory):

--- a/platform/src/petition/models.py
+++ b/platform/src/petition/models.py
@@ -161,7 +161,7 @@ class PetitionRatio(enum.Enum):
 
 class Petition:
     """The petition data"""
-    def __init__(self, date, ratio, otn, judge, complaint_date, arrest_date):
+    def __init__(self, date, ratio, otn, judge, complaint_date, arrest_date, defendant_name):
 
         if not isinstance(ratio, PetitionRatio):
             raise ValueError("Invalid PetitionRatio")
@@ -169,10 +169,10 @@ class Petition:
         self.date = date
         self.ratio = ratio
         self.otn = otn
-        self.arrest_date = arrest_date
         self.complaint_date = complaint_date
         self.arrest_date = arrest_date
         self.judge = judge
+        self.defendant_name = defendant_name
 
     @staticmethod
     def from_dict(data):
@@ -192,10 +192,11 @@ class Petition:
             data["judge"],
             complaint_date, 
             arrest_date, 
+            data["defendant_name"],
         )
 
     def __repr__(self):
-        return f"Petition({repr(self.date)}, {self.ratio}, {self.otn}, {self.arrest_date}, {self.complaint_date}, {self.judge})"
+        return f"Petition({repr(self.date)}, {self.ratio}, {self.otn}, {self.arrest_date}, {self.complaint_date}, {self.judge}, {self.defendant_name})"
 
 
 class Fines:

--- a/platform/src/petition/models.py
+++ b/platform/src/petition/models.py
@@ -161,7 +161,7 @@ class PetitionRatio(enum.Enum):
 
 class Petition:
     """The petition data"""
-    def __init__(self, date, ratio, otn, judge, complaint_date, arrest_date, defendant_name):
+    def __init__(self, date, ratio, otn, judge, complaint_date, arrest_date):
 
         if not isinstance(ratio, PetitionRatio):
             raise ValueError("Invalid PetitionRatio")
@@ -172,7 +172,6 @@ class Petition:
         self.complaint_date = complaint_date
         self.arrest_date = arrest_date
         self.judge = judge
-        self.defendant_name = defendant_name
 
     @staticmethod
     def from_dict(data):
@@ -192,11 +191,10 @@ class Petition:
             data["judge"],
             complaint_date, 
             arrest_date, 
-            data["defendant_name"],
         )
 
     def __repr__(self):
-        return f"Petition({repr(self.date)}, {self.ratio}, {self.otn}, {self.arrest_date}, {self.complaint_date}, {self.judge}, {self.defendant_name})"
+        return f"Petition({repr(self.date)}, {self.ratio}, {self.otn}, {self.arrest_date}, {self.complaint_date}, {self.judge})"
 
 
 class Fines:

--- a/platform/src/petition/tests/test_rest.py
+++ b/platform/src/petition/tests/test_rest.py
@@ -5,6 +5,7 @@ from django.test import TestCase
 from django.urls import reverse
 from expunger.tests.test_rest import Authenticated
 from petition import factories
+from expunger.factories import OrganizationFactory, AttorneyFactory
 
 from docket_parser import test_data_path
 
@@ -19,6 +20,8 @@ class TestPetitionAPI(Authenticated, TestCase):
         petition = factories.PetitionFactory()
         fines = factories.FinesFactory()
         charges = [factories.ChargeFactory(), factories.ChargeFactory()]
+        organization = OrganizationFactory()
+        attorney = AttorneyFactory()
 
         return {
             "petitioner": {
@@ -41,6 +44,7 @@ class TestPetitionAPI(Authenticated, TestCase):
                 "ratio": petition.ratio.name,
                 "otn": petition.otn,
                 "judge": petition.judge,
+                "defendant_name": petition.defendant_name,
             },
             "dockets": [str(docket)],
             "fines": {
@@ -63,6 +67,28 @@ class TestPetitionAPI(Authenticated, TestCase):
                 "disposition": charges[1].disposition,
                 }
             ],
+            "category": "Docket",
+            "organization": {
+                "name": organization.name,
+                "address": {
+                    "pk": 1,
+                    "street1": organization.address.street1,
+                    "street2": organization.address.street2,
+                    "city": organization.address.city,
+                    "state": organization.address.state,
+                    "zipcode": organization.address.zipcode
+                },
+                "phone": organization.phone,
+                "pk": 1,
+                "url": "http://localhost:8000/api/v0.2.0/expunger/organization/1",
+            },
+            "attorney": {
+                "name": f"{attorney.user.first_name} {attorney.user.last_name}",
+                "bar": attorney.bar,
+                "pk": 1,
+                "url": "http://localhost:8000/api/v0.2.0/expunger/attorney/1/",
+                "user_id": 1,
+            },
         }
 
     def test_petition(self):
@@ -141,7 +167,8 @@ class TestDocketParserAPI(Authenticated, TestCase):
                 "complaint_date": "1913-11-16",
                 "arrest_date": "1902-04-11",
                 "otn": "T 760873-7",
-                "ratio": "full"
+                "ratio": "full",
+                "defendant_name": "Real B. Person"
             }
         )
 
@@ -324,7 +351,7 @@ class TestDocketParserAPI(Authenticated, TestCase):
                 assert response.status_code == 200
                 expected_keys = {"petitioner", "petitions"}
                 assert set(response.json().keys()) == expected_keys
-                expected_petition_keys = {"charges", "docket_info", "docket_numbers", "fines"}
+                expected_petition_keys = {"charges", "docket_info", "docket_numbers", "fines", "category"}
                 assert set(response.json()["petitions"][0].keys()) == expected_petition_keys
 
     def test_multidockets_1(self):

--- a/platform/src/petition/tests/test_rest.py
+++ b/platform/src/petition/tests/test_rest.py
@@ -44,7 +44,6 @@ class TestPetitionAPI(Authenticated, TestCase):
                 "ratio": petition.ratio.name,
                 "otn": petition.otn,
                 "judge": petition.judge,
-                "defendant_name": petition.defendant_name,
             },
             "dockets": [str(docket)],
             "fines": {
@@ -168,7 +167,6 @@ class TestDocketParserAPI(Authenticated, TestCase):
                 "arrest_date": "1902-04-11",
                 "otn": "T 760873-7",
                 "ratio": "full",
-                "defendant_name": "Real B. Person"
             }
         )
 

--- a/platform/src/petition/views.py
+++ b/platform/src/petition/views.py
@@ -230,7 +230,6 @@ class DocketParserAPIView(APIView):
                         petition["docket_info"] = petition_from_parser(parsed)
                         if parsed["type"] == "docket":
                             petition["fines"] = models.Fines.from_dict(fines_from_parser(parsed)).to_dict()
-                            petition["docket_info"]["defendant_name"] = parsed.get("defendant_name")
                 if not petition["docket_info"]:
                     petition["docket_info"] = petition_from_parser(parsed)
                 if not petition["fines"] and parsed["type"] == "docket":

--- a/platform/src/petition/views.py
+++ b/platform/src/petition/views.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+import json
 import os
 import re
 import traceback
@@ -16,6 +17,7 @@ from rest_framework.views import APIView
 
 import docket_parser
 from . import models
+from expunger.models import Organization, Attorney
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 logger = logging.getLogger("django")
@@ -26,14 +28,15 @@ logger.info(f"DJANGO_LOG_LEVEL: {os.environ.get('DJANGO_LOG_LEVEL')}")
 class PetitionAPIView(APIView):
     def post(self, request, *args, **kwargs):
         logger.debug("PetitionAPIView post")
-        profile = request.user.expungerprofile
+        # profile = request.user.expungerprofile
 
-        logger.debug(f"Profile {profile} found attorney {profile.attorney}")
+        # logger.debug(f"Profile {profile} found attorney {profile.attorney}")
+
 
         try:
             context = {
-                "organization": profile.organization,
-                "attorney": profile.attorney,
+                "organization": Organization.from_dict(request.data["organization"]),
+                "attorney": Attorney.from_dict(request.data["attorney"]),
                 "petitioner":
                     models.Petitioner.from_dict(request.data["petitioner"]),
                 "petition":
@@ -116,7 +119,7 @@ class DocketParserAPIView(APIView):
     def post(self, request: Request, *args, **kwargs):
         logger.debug("DocketParserAPIView post")
 
-        profile = request.user.expungerprofile
+        # profile = request.user.expungerprofile
 
         try:
             df = request.FILES.getlist("docket_file")
@@ -125,12 +128,23 @@ class DocketParserAPIView(APIView):
             logger.warning(msg)
             return Response({"error": msg}, status=status.HTTP_400_BAD_REQUEST)
 
-        grouped_dockets = {}
+        petitioner_json = request.POST.get("petitioner")
+        petitioner = None
+        if petitioner_json:
+            try:
+                petitioner = json.loads(petitioner_json)
+            except json.JSONDecodeError as e:
+                logger.warning("Error decoding petitioner_json")
+                logger.warning("petitioner_json:", petitioner_json)
+                raise e
 
         content = {
-            "petitioner": None,
-            "petitions": []
+            "petitioner": petitioner,
+            "petitions": [],
         }
+
+        grouped_dockets = {}
+
         for file in df:
             try:
                 parsed = docket_parser.parse_pdf(file)
@@ -156,20 +170,31 @@ class DocketParserAPIView(APIView):
                 "docket_info": {},
                 "docket_numbers": [],
                 "charges": [],
-                "fines": {}
+                "fines": {},
+                "category": "",
             }
             for parsed in group:
                 if parsed["type"] == "court summary":
-                    # TODO: handle dockets from court summaries that have county data other than: {'county': 'Philadelphia'}.  The same OTN and/or docket numbers may have been addressed by courts in multiple counties, eg. Philadelphia County and Montgomery County
-                    # NOTE from 6/23/2023 meeting with PLSE attorney: "It would be nice to have those petitions drafted for out of county, but it is a low priority"
+                    # TODO: handle dockets from court summaries that have county data other than: {'county': 'Philadelphia'}.
+                    # The same OTN and/or docket numbers might have been addressed by courts in multiple counties, 
+                    # eg. Philadelphia County and Montgomery County
+
+                    # "county" key used to alert user when a court summary record is from a county other than Philadelpyhia County
                     petition["county"] = parsed.get("county")
-                        
-                    petition["category"] = parsed["category"]
+                    
                     if parsed["category"] == 'Archived':
-                        # NOTE from 6/23/2023 meeting with PLSE attorney: "After uploading the court summary, we could alert the user to the fact that certain dockets are archived, and then allow them to upload the archived docket sheets."
+                        # "category" key used to alert user when petition info is only taken from a court summary
+                        # or an archived docket from a court summary
+                        if not petition["category"]:
+                            petition["category"] = parsed["category"]
+
                         if parsed.get("docket_number") not in petition["docket_numbers"]:
                             petition["docket_numbers"].append(parsed.get("docket_number"))
-                        continue 
+
+                    elif not petition["category"]:
+                        petition["category"] = parsed["category"]
+                else:
+                    petition["category"] = "Docket"
 
                 petitioner = petitioner_from_parser(parsed)
                 if content["petitioner"] is None:
@@ -205,6 +230,7 @@ class DocketParserAPIView(APIView):
                         petition["docket_info"] = petition_from_parser(parsed)
                         if parsed["type"] == "docket":
                             petition["fines"] = models.Fines.from_dict(fines_from_parser(parsed)).to_dict()
+                            petition["docket_info"]["defendant_name"] = parsed.get("defendant_name")
                 if not petition["docket_info"]:
                     petition["docket_info"] = petition_from_parser(parsed)
                 if not petition["fines"] and parsed["type"] == "docket":


### PR DESCRIPTION
## Overview

This PR revamps the FileUpload component to provide a preview of the petitions that will be generated while allowing the user to upload additional documents as needed.
The preview includes:

- organization name and address
- attorney name and bar number
- petitioner info (reusing the Petitioner component from the `/generate` page so it can be edited and saved)
- a table of petition info with:
    - the total number of petitions that will be created
    - a row for each petition with OTN, docket numbers, case names

Instead adding an additional page between `/upload` and `/generate` as original described in issue #14, I've add preview components to the `/upload` page and turned the upload modal into an actual modal that can be opened when the user wants to add a new document.  I did this because it is much easier to keep track of the documents that have already been uploaded in one component, as well as tracking things like the user's selection of what petitions to not generate.

A few notes about the features this PR adds:

1. The upload modal automatically pops up the first time a user goes to the `/upload` page, and if no documents have been uploaded, a warning message is shown and the user cannot continue with the generation process.
2. The preview includes the organization and attorney info that will be shown on the petition.  To get that info, I added a request in `context/user.js` to fetch the user's profile info, which is then stored in the user context.  That info is also included in the `/generate` request data to create the petition.  Instead of using the user's profile in PetitionAPIView, the organization and attorney instances are being created from the request data.
3. I am using the "category" attribute from court summaries, plus a default "Docket" value if a docket has been uploaded, to show alerts in the Petitions table.  A yellow "A" with a tooltip indicating the record is from an archive, a blue "S" indicating the record is from a court summary, and a red "C" to warn that the record may not be from Philadelphia county.  The "A" and "S" warnings are meant to prompt the user to upload a corresponding docket if it is available.  The "C" warning is just for the user's information because we aren't currently addressing expungements in other counties.
4. There are checkboxes for each petition that the user can select to omit a petition from the generation process.  The check mark adds the petition numbers to an array that I am using to filter which petitions are kept when the user proceeds to the `/generate` page.
5. ~I've added a "defendant_name" attribute to the petition data so that the case title can be shown.~


### Does this close any currently open issues?

<!-- Change ### to #[number of issue], e.g. #1 -->
Closes #14 

### Testing Instructions

- Try out the new page by uploading several dockets as well as a court summary to see the little alert tooltips
- Run backend tests.  Tests in petition/tests/test_rest.py have been updated for the new "defendant_name" and "category" attributes

### Before merging

- [ ] PR has been reviewed and approved
- [ ] All tests should pass, [testing instructions are here](https://github.com/Philadelphia-Lawyers-for-Social-Equity/docket_dashboard#testing).
- [ ] Branch has been rebased on `develop` (or the branch being merged to). [See here for rebase instructions](https://github.com/Philadelphia-Lawyers-for-Social-Equity/docket_dashboard/blob/develop/CONTRIBUTING.md#reviewed-work)
