### PR TITLE
Fix GeneratePage Tab Navigation and Field Editing

### DIFF
--- a/frontend/src/src/components/GeneratePage/components/Charges.js
+++ b/frontend/src/src/components/GeneratePage/components/Charges.js
@@ -9,7 +9,12 @@ export default function Charges({petitionNumber, disabled}) {
         - disabled: boolean
     */
     const { petitions, updatePetitions } = usePetitions();
-    const charges = petitions[petitionNumber].charges;
+    
+    const charges = petitions[petitionNumber].charges.map((charge, idx) => {
+        const key = `${petitions[petitionNumber].charges.length}-${idx}`
+        charge["key"] = key;
+        return charge
+    });
 
     function handleChange(newCharges) {
         updatePetitions('charges', petitionNumber, newCharges)

--- a/frontend/src/src/components/GeneratePage/components/Dockets.js
+++ b/frontend/src/src/components/GeneratePage/components/Dockets.js
@@ -12,7 +12,7 @@ export default function Dockets({petitionNumber, disabled}) {
     const docket_numbers = petitions[petitionNumber].docket_numbers;
 
     function makeItems() {
-        return(docket_numbers.map((d) => ({"text": d, "key": d})));
+        return(docket_numbers.map((d,idx) => ({"text": d, "key": `${docket_numbers.length}-${idx}`})));
     }
 
     function handleChange(items) {

--- a/frontend/src/src/components/GeneratePage/components/Petitioner.js
+++ b/frontend/src/src/components/GeneratePage/components/Petitioner.js
@@ -27,7 +27,7 @@ export default function Petitioner(props) {
             return([]);
         }
 
-        return props.aliases.map((a) => ({"text": a, "key": a}));
+        return props.aliases.map((a, idx) => ({"text": a, "key": `${props.aliases.length}-${idx}`}));
     }
 
     function saveAliases(items) {

--- a/frontend/src/src/components/GeneratePage/helpers/EditableList.js
+++ b/frontend/src/src/components/GeneratePage/helpers/EditableList.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Button, Col, Form, Row } from 'react-bootstrap';
-import { v4 as uuidv4 } from 'uuid';
 
 export default function EditableList(props) {
     /* Turn a list of property objects into specified items, including widgets
@@ -14,6 +13,7 @@ export default function EditableList(props) {
             - items: array of property objects appropriate for Inner component
             - handleChange
             - smallHeader: should the header be in a small font?
+            - disabled: boolean
     */
 
     const Inner = props.inner;
@@ -39,7 +39,9 @@ export default function EditableList(props) {
 
     function isEmpty(obj) {
         let objString = JSON.stringify(obj);
-        let emptyString = JSON.stringify(props.emptyItem);
+        let newItem = props.emptyItem;
+        newItem["key"] = `${props.items.length}-${props.items.length - 1}`
+        let emptyString = JSON.stringify(newItem);
         return(objString === emptyString);
     }
 
@@ -73,14 +75,16 @@ export default function EditableList(props) {
     return (
         <Form.Group as="div">
             {showLabel()}
-            { props.items.map((innerProps, idx) => {
-                    return(
-                        <Inner
-                            {...innerProps}
-                            key={uuidv4()}
-                            handleChange={(txt) => {updateItem(idx, txt);}}
-                            handleRemove={() => { dropItem(idx);}}
-                />);
+            {props.items.map((innerProps, idx) => {
+                return (
+                    <Inner
+                        {...innerProps}
+                        key={innerProps.key}
+                        handleChange={(txt) => {updateItem(idx, txt);}}
+                        handleRemove={() => { dropItem(idx);}}
+                        disabled={props.disabled || false}
+                    />
+                );
             })}
 
             <Row>

--- a/frontend/src/src/components/GeneratePage/helpers/GeneratorInput.js
+++ b/frontend/src/src/components/GeneratePage/helpers/GeneratorInput.js
@@ -11,6 +11,7 @@ export default function GeneratorInput(props) {
         - name
         - value
         - handleChange
+        - disabled: boolean
     */
 
     if (!props.name) {

--- a/frontend/src/src/components/GeneratePage/helpers/RemovableCharge.js
+++ b/frontend/src/src/components/GeneratePage/helpers/RemovableCharge.js
@@ -11,7 +11,7 @@ export default function RemovableCharge(props) {
         - disposition
         - handleChange
         - handleRemove
-
+        - disabled
     */
 
     const [statute, setStatute] = useState(props.statute || "");
@@ -20,7 +20,6 @@ export default function RemovableCharge(props) {
     const [date, setDate] = useState(props.date || "");
     const [disposition, setDisposition] = useState(props.disposition || "");
 
-    const [editing, setEditing] = useState(false);
     const [hovering, setHovering] = useState(false);
 
     function save() {
@@ -30,24 +29,20 @@ export default function RemovableCharge(props) {
             "grade": grade,
             "date": date,
             "disposition": disposition,
-            "key": description
         });
-        setEditing(false);
     }
 
     return (
         <div
-            onFocus={() => {setEditing(true);}}
             onBlur={() => {save();}}
         >
         <Row className="mb-2">
-            <Col sm={2}><Form.Label>{props.label || ""}</Form.Label></Col>
+            <Col sm={2}></Col>
             <Col sm={2}>
                 <Form.Control
                     placeholder="Statute"
                     value={statute}
                     onChange={(e) => {setStatute(e.target.value);}}
-                    readOnly={!editing}
                     disabled={props.disabled || false}
                 />
             </Col>
@@ -56,7 +51,6 @@ export default function RemovableCharge(props) {
                     placeholder="grade"
                     value={grade}
                     onChange={(e) => {setGrade(e.target.value);}}
-                    readOnly={!editing}
                     disabled={props.disabled || false}
                 />
             </Col>
@@ -65,7 +59,6 @@ export default function RemovableCharge(props) {
                     type="date"
                     value={date}
                     onChange={(e) => {setDate(e.target.value);}}
-                    readOnly={!editing}
                     disabled={props.disabled || false}
                 />
             </Col>
@@ -74,21 +67,20 @@ export default function RemovableCharge(props) {
                     placeholder="Disposition"
                     value={disposition}
                     onChange={(e) => {setDisposition(e.target.value);}}
-                    readOnly={!editing}
                     disabled={props.disabled || false}
                 />
             </Col>
             <Col sm={1}>
-            <Button
-                variant={ hovering ? "danger" : "secondary"}
-                onClick={ props.handleRemove }
-                cursor="pointer"
-                disabled={props.disabled || false}
-                onMouseOver={() => {setHovering(true);}}
-                onMouseOut={() => {setHovering(false);}}
-            >
-                X
-            </Button>
+                <Button
+                    variant={ hovering ? "danger" : "secondary"}
+                    onClick={ props.handleRemove }
+                    cursor="pointer"
+                    disabled={props.disabled || false}
+                    onMouseOver={() => {setHovering(true);}}
+                    onMouseOut={() => {setHovering(false);}}
+                >
+                    X
+                </Button>
             </Col>
         </Row>
         <Row>
@@ -97,7 +89,6 @@ export default function RemovableCharge(props) {
                 <Form.Control
                     value={description}
                     onChange={(e) => {setDescription(e.target.value);}}
-                    readOnly={!editing}
                     disabled={props.disabled || false}
                 />
             </Col>

--- a/frontend/src/src/components/GeneratePage/helpers/RemovableTextField.js
+++ b/frontend/src/src/components/GeneratePage/helpers/RemovableTextField.js
@@ -9,19 +9,18 @@ export default function RemovableTextField(props) {
         - text
         - handleChange
         - handleRemove
+        - disabled
     */
 
     const [text, setText] = useState(props.text);
-    const [editing, setEditing] = useState(false);
     const [hovering, setHovering] = useState(false);
 
     function save() {
-        setEditing(false);
-        props.handleChange({"text": text, "key": text});
+        props.handleChange({"text": text});
     }
 
     function handleEnterKey(press) {
-        if (editing && press.key === "Enter") {
+        if (press.key === "Enter") {
             save();
         }
     }
@@ -38,11 +37,9 @@ export default function RemovableTextField(props) {
             <Col sm={7}>
             <Form.Control
                 onChange={e => { setText(e.target.value)}}
-                onFocus={() => setEditing(true)}
                 onBlur={() => save()}
                 onKeyDown={(e) => {handleEnterKey(e)}}
                 value={text}
-                readOnly={ !editing }
                 disabled={ props.disabled || false }
             />
             </Col>


### PR DESCRIPTION

## Overview

This PR makes changes to GeneratePage and its child components to allow keyboard/tab navigation of the `/generate` page and make the form fields more consistent.

The Aliases, Dockets, and Charges fields of the `/generate` page were unable to be navigated using the tab key.  This PR fixes that issue by changing the `key` prop of the `<Inner>` component in EditableList.  Instead of using a uuid, which is re-generated as a random number on every re-rendering of the component, the key is now a string based on the number of components in the list and the index of the rendered item.  The goal is to have a key that is (1) consistent enough for React to keep track of changes and where focus is between renders and (2) unique enough to not be confused with another list item.

On single petition generation, the form fields on the `/generate` page are supposed to be disabled when a user selects the 'Generate Petition` button and then become editable again if the user selects `Edit Petition`.  This was not working properly for the Aliases, Dockets, and Charges sections.  Adding a `disabled` prop to the `<Inner>` component in EditableList fixes that issue.

For the sake of visual consistency and simplicity, I have removed the `readOnly={!editing}` attributes of the form fields in RemovableCharge and RemovableTextField.  Those attributes were making the fields appear greyed-out and not editable, but they were editable as soon as they were focused, so the `readOnly` attribute had no function.  I also removed the `const [editing, setEditing] = useState(false);` and related uses of `editing` because it seems to have no function.

The `/generate` page used to look like this:
![image](https://github.com/user-attachments/assets/8376157d-564d-4195-a30a-a9687079a39c)

And now it looks like this:
![image](https://github.com/user-attachments/assets/5e62d969-706a-4905-a157-deb6414ae237)


### Does this close any currently open issues?

<!-- Change ### to #[number of issue], e.g. #1 -->
Closes #25
and
Closes #40 

### Testing Instructions

Go through the petition generation process on the frontend.  On the `/generate` page, test to see whether:

1. You can use your keyboard's tab key to navigate through all the form fields on the page.
2. Make some changes, additions, or deletions to the aliases, docket numbers, or charges to make sure the changes can be made, that, you can still navigate with your keyboard, and that the changes are used when you select to generate the petition.

### Before merging

- [x] PR has been reviewed and approved
- [x] Branch has been rebased on `develop` (or the branch being merged to). [See here for rebase instructions](https://github.com/Philadelphia-Lawyers-for-Social-Equity/docket_dashboard/blob/develop/CONTRIBUTING.md#reviewed-work)
