### PR TITLE
feat #20 - Switch to partial expungement when user deletes a charge

### DIFF
--- a/frontend/src/src/components/GeneratePage/components/Petition.js
+++ b/frontend/src/src/components/GeneratePage/components/Petition.js
@@ -1,52 +1,69 @@
-import React from "react";
+import React, { useRef, useEffect } from "react";
 import GeneratorInput from "../helpers/GeneratorInput";
 import Radio from "../helpers/Radio";
 import { usePetitions } from "../../../context/petitions";
 
-export default function Petition({petitionNumber, disabled}) {
-    /* props expects:
+export default function Petition({ petitionNumber, disabled }) {
+  /* props expects:
         - petitionNumber: integer
         - disabled: boolean
     */
-    const { petitions, updatePetitions } = usePetitions();
-    const docket_info = petitions[petitionNumber].docket_info;
+  const { petitions, updatePetitions } = usePetitions();
+  const docket_info = petitions[petitionNumber].docket_info;
 
-    function handleChange(changes) {
-        updatePetitions('docket_info', petitionNumber, changes)
+  // store the original total of charges in a ref
+  const totalChargesRef = useRef();
+  useEffect(() => {
+    if (totalChargesRef.current === undefined) {
+      totalChargesRef.current = getCurrentTotalCharges();
     }
+  }, [petitionNumber, petitions]);
+  const totalCharges = totalChargesRef.current;
 
-    return (
-        <>
-            <h2>Petition</h2>
-            <GeneratorInput
-                label="Offense Tracking Number (OTN)"
-                type="text"
-                placeholder="########"
-                name="otn"
-                value={docket_info.otn}
-                handleChange={handleChange}
-                disabled={disabled || false}
-            />
-            <GeneratorInput
-                label="Judge"
-                type="text"
-                placeholder="First & Last Name"
-                name="judge"
-                value={docket_info.judge}
-                handleChange={handleChange}
-                disabled={disabled || false}
-            />
-            <Radio
-                label="Is this a full or partial expungement?"
-                name="ratio"
-                handleChange={handleChange}
-                items={[
-                    ["full", "Full Expungement"],
-                    ["partial", "Partial Expungement"],
-                ]}
-                selected={docket_info.ratio || "full"}
-                disabled={disabled || false}
-            />
-        </>
-    );
+  // get the current total charges for the petition
+  const getCurrentTotalCharges = () => petitions[petitionNumber].charges.length;
+
+  // check whether current number of charges is less than the original amount
+  const isPartialExpungement = () => totalCharges > getCurrentTotalCharges();
+
+  function handleChange(changes) {
+    updatePetitions("docket_info", petitionNumber, changes);
+  }
+
+  return (
+    <>
+      <h2>Petition</h2>
+      <GeneratorInput
+        label="Offense Tracking Number (OTN)"
+        type="text"
+        placeholder="########"
+        name="otn"
+        value={docket_info.otn}
+        handleChange={handleChange}
+        disabled={disabled || false}
+      />
+      <GeneratorInput
+        label="Judge"
+        type="text"
+        placeholder="First & Last Name"
+        name="judge"
+        value={docket_info.judge}
+        handleChange={handleChange}
+        disabled={disabled || false}
+      />
+      <Radio
+        label="Is this a full or partial expungement?"
+        name="ratio"
+        handleChange={handleChange}
+        items={[
+          ["full", "Full Expungement"],
+          ["partial", "Partial Expungement"],
+        ]}
+        selected={
+          (isPartialExpungement() && "partial") || docket_info.ratio || "full"
+        }
+        disabled={disabled || false}
+      />
+    </>
+  );
 }


### PR DESCRIPTION
## Overview

When a charge is deleted from the list, the full expungement radio button will automatically switch to partial. In addition, if a user adds any charges back and the total charges is at least the same as the original total number of charges, the radio button will automatically switch back from partial to full.

[PA_Expunger_PR_20_Proof_of_Testing_1.webm](https://github.com/user-attachments/assets/d9d4dfa1-57a8-49be-ac28-aee648d1f48f)

Closes #20 
Note: This closes the immediate issue, but we could consider in the future adding a notification or toast to make it more apparent to the user that full was changed to partial. I'm happy to look into this further if that's the way we want to go.

### Testing Instructions

Test Scenario 1: 
- [ ] On a brand new form, switch from **Partial Expungement** to **Full Expungement** and back before removing or adding any charges.
- [ ] Confirm that you can switch between the charges without issue.

Test Scenario 2:
- [ ] Refresh the page, or continue from Test Scenario 1 and flip the button back to full.
- [ ] Remove a charge or two.
- [ ] Confirm that **Full Expungement** switches to **Partial Expungement**.
- [ ] Confirm that you _cannot_ change to **Full Expungement**.

Test Scenario 3: 
- [ ] Continue from Test Scenario 2
- [ ] Add a new charge (or enough to get back to the original amount of charges).
- [ ] Confirm that **Partial Expungement** switches back to **Full Expungement**. 

Test Scenario 4: 
- [ ] Continue from Test Scenario 3
- [ ] Add another charge (i.e., add more than the original total of charges).
- [ ] Confirm that **Full Expungement** does _not_ change to **Partial Expungement**.
