### PR TITLE
Handle blank final page of court summary document

### DIFF
--- a/platform/docket_parser/src/docket_parser/parsing.py
+++ b/platform/docket_parser/src/docket_parser/parsing.py
@@ -351,6 +351,9 @@ def remove_court_summary_page_breaks(extracted_text: str) -> str:
                     # Include anything after '(Continued)' textbox wrap
                     post_page_break = line.split(DocketReader.box_wrap, 1)[1]
                     output_lines.append(post_page_break)
+                elif re.match(printed_date_line_regex, line):
+                    logger.debug(f"begin page break matched: {line}")
+                    in_page_break = True
                 else:
                     output_lines.append(line)
         elif re.match(printed_date_line_regex, line):


### PR DESCRIPTION
## Overview

Hi, there! My name is Tyler, and I work for a small non-profit organization called Free Our Vote. We partner with community and legal aid groups to restore voting rights for folks with past convictions. Thank you immensely for your work here — this saved me a significant amount of time in determining restoration eligibility via the UJS court summary documents.

In going through this exercise, I noticed that the document parser errored out when the final page of the court summary is mostly blank, except for some lingering "(Continued)" headers (around 10 percent of the documents I was working with, if I recall correctly). This PR contains a quick and dirty fix for that bug. I've included some example docket numbers below.

_Somewhat related: I also needed the sentencing information for each charge to determine eligibility and extended the court summary grammar to extract these values (i.e., "Sentence Dt.," "Sentence Type," "Program Period," and "Sentence Length") as well. I'm less familiar with expungement eligibility, but if this sounds like it may be of use here, I'm happy to open another PR — just let me know!_

### Does this close any currently open issues?

No

### Testing Instructions

- Run the `python -m docket_parser <pdf_file_path>` command for the court summary documents related to the following docket numbers:
    - [ ] CP-51-CR-0000488-2010
    - [ ] CP-51-CR-0002481-2024
    - [ ] CP-51-CR-0003497-2013
    - [ ] MC-51-CR-0000989-2019
    - [ ] MC-51-CR-0002709-2019
    - [ ] MC-51-CR-0010693-2022

### Before merging

- [ ] PR has been reviewed and approved
- [ ] All tests should pass, [testing instructions are here](https://github.com/Philadelphia-Lawyers-for-Social-Equity/docket_dashboard#testing).
- [ ] Branch has been rebased on `develop` (or the branch being merged to). [See here for rebase instructions](https://github.com/Philadelphia-Lawyers-for-Social-Equity/docket_dashboard/blob/develop/CONTRIBUTING.md#reviewed-work)
