### PR TITLE
15 alert on leave page

### DIFF
--- a/frontend/src/src/App.jsx
+++ b/frontend/src/src/App.jsx
@@ -16,6 +16,7 @@ import ReviewPage from "./components/ReviewPage";
 import Nav from "./components/nav";
 import PageNotFound from "./components/PageNotFound";
 import { PetitionsProvider } from "./context/petitions";
+import {NavBlockProvider} from "./context/navBlockContext.jsx";
 
 function App(props) {
     return (
@@ -24,19 +25,21 @@ function App(props) {
                 <PetitionerProvider>
                     <PetitionsProvider>
                         <UserProvider>
-                            <Nav/>
-                            <Switch>
-                                <Route exact path="/login" component={LoginForm}/>
-                                {/* <Route exact path="/signup" component={SignUp} /> */}
-                                <PrivateRoute exact path="/" component={LandingPage}/>
-                                <PrivateRoute exact path="/action" component={ChooseAction}/>
-                                {/*<PrivateRoute exact path="/search" component={SearchPage} />*/}
-                                {/*<PrivateRoute exact path="/profile" component={ProfilePage}/>*/}
-                                <PrivateRoute exact path="/upload" component={FileUpload}/>
-                                <PrivateRoute exact path="/generate" component={GeneratePage}/>
-                                <PrivateRoute exact path="/review" component={ReviewPage}/>
-                                <Route path="*" component={PageNotFound}/>
-                            </Switch>
+                            <NavBlockProvider>
+                                <Nav/>
+                                <Switch>
+                                    <Route exact path="/login" component={LoginForm}/>
+                                    {/* <Route exact path="/signup" component={SignUp} /> */}
+                                    <PrivateRoute exact path="/" component={LandingPage}/>
+                                    <PrivateRoute exact path="/action" component={ChooseAction}/>
+                                    {/*<PrivateRoute exact path="/search" component={SearchPage} />*/}
+                                    {/*<PrivateRoute exact path="/profile" component={ProfilePage}/>*/}
+                                    <PrivateRoute exact path="/upload" component={FileUpload}/>
+                                    <PrivateRoute exact path="/generate" component={GeneratePage}/>
+                                    <PrivateRoute exact path="/review" component={ReviewPage}/>
+                                    <Route path="*" component={PageNotFound}/>
+                                </Switch>
+                            </NavBlockProvider>
                         </UserProvider>
                     </PetitionsProvider>
                 </PetitionerProvider>

--- a/frontend/src/src/components/FileUpload/index.jsx
+++ b/frontend/src/src/components/FileUpload/index.jsx
@@ -5,6 +5,8 @@ import { Alert, Button, Card, Container } from 'react-bootstrap';
 import { usePetitioner } from '../../context/petitioner';
 import { initialPetitionState, usePetitions } from '../../context/petitions';
 import { useUser } from '../../context/user';
+import { useNavBlock } from "../../context/navBlockContext.jsx";
+import NavBlock from "../util/navBlock";
 import Attorney from './components/Attorney';
 import Petitioner from '../GeneratePage/components/Petitioner';
 import PetitionTable from './components/PetitionTable';
@@ -16,12 +18,23 @@ export default function FileUpload(props) {
     const history = useHistory();
     const { user, initialUserState } = useUser();
     const { petitioner } = usePetitioner();
-    const { petitions, setPetitions } = usePetitions();
+    const { petitions, setPetitions, setPetitionNumber } = usePetitions();
+    const { blockNavRef, setBlockNav } = useNavBlock();
     
     const [doNotGenerate, setDoNotGenerate] = useState([]);
     const [pageError, setPageError] = useState("");
     const [showUploadModal, setShowUploadModal] = useState(false);
     const [petitionCount, setPetitionCount] = useState(0);
+
+    useEffect(() => {
+        // When this component mounts, turn on nav block
+        setBlockNav(true);
+
+        // cleanup on unmount
+        return () => {
+            setBlockNav(false);
+        };
+    }, [setBlockNav]);
 
     const handleClose = () => setShowUploadModal(false);
     const handleShow = () => {
@@ -34,34 +47,36 @@ export default function FileUpload(props) {
         // remove petitions from array if user has selected to omit them
         const petitionsToGenerate = petitions.filter(petition => {
             if (petition.docket_info.otn && doNotGenerate.includes(petition.docket_info.otn)) {
-                return false
+                return false;
             }
             for (const num of petition.docket_numbers) {
                 if (doNotGenerate.includes(num)) {
-                    return false
+                    return false;
                 }
             }
-            return true
+            return true;
         })
-        setPetitions(petitionsToGenerate)
+        setPetitions(petitionsToGenerate);
+        setPetitionNumber(0);
         history.push("/generate", {"petitionFields": {petitions: petitionsToGenerate, petitioner}});
     }
 
     // show upload modal when page first loads and/or no petitions have been uploaded
     useEffect(() => {
         if (petitions === initialPetitionState) {
-            handleShow()
+            handleShow();
         }
         // eslint-disable-next-line
     }, [])
 
     if (!user || user.attorney === initialUserState.attorney || user.organization === initialUserState.organization) {
         // Wait for attorney and org data, they are required to proceed.
-        return <FallbackMessage/>
+        return <FallbackMessage/>;
     }
 
     return (
         <div>
+            <NavBlock blockNav={blockNavRef} />
             <Container fluid className="pt-4">
                 <div className="d-flex justify-content-between mb-4">
                     <h4>Petition Generation Preview</h4>

--- a/frontend/src/src/components/GeneratePage/index.jsx
+++ b/frontend/src/src/components/GeneratePage/index.jsx
@@ -12,8 +12,9 @@ import { useAuth } from "../../context/auth";
 import { useUser } from '../../context/user';
 import { initialPetitionState, usePetitions } from "../../context/petitions";
 import { usePetitioner, initialPetitionerState } from "../../context/petitioner";
-import { useIsMounted } from "../../hooks/useIsMounted";
+import { useNavBlock } from "../../context/navBlockContext.jsx";
 import NavBlock from "../util/navBlock";
+import { useIsMounted } from "../../hooks/useIsMounted";
 
 import "./style.css";
 import api from "../../services/api";
@@ -32,13 +33,13 @@ export default function GeneratePage(props) {
     const { user } = useUser();
     const { petitioner, setPetitioner } = usePetitioner();
     const { petitions, setPetitions, petitionNumber, setPetitionNumber } = usePetitions();
+    const { blockNavRef, setBlockNav } = useNavBlock();
     const getIsMounted = useIsMounted();
 
     const [success, setSuccess] = useState(false);
     const [busy, setBusy] = useState(false);
     const [downloadUrls, setDownloadUrls] = useState({0: ""});
     const [error, setError] = useState("");
-    let shouldBlockNav = useRef(true);
 
     const formDisabled = busy || success[petitionNumber];
     const totalPetitions = petitions.length;
@@ -65,6 +66,17 @@ export default function GeneratePage(props) {
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
+
+    useEffect(() => {
+        // When this component mounts, turn on nav block
+        setBlockNav(true);
+
+        // cleanup on unmount
+        return () => {
+            setBlockNav(false);
+        };
+    }, [setBlockNav]);
+
 
     async function postGeneratorRequest() {
         let petitionFields = {
@@ -200,15 +212,13 @@ export default function GeneratePage(props) {
             if (petitionNumber === totalPetitions - 1) {
                 // TODO: Should this info be saved to page history? delete if not
 
-                // Don't ask the user whether they want to navigate; just navigate
-                shouldBlockNav.current = false;
+                // because "/review" is in the list of safe paths, we don't have to change the navBlock ref
                 history.push("/review", {
                     "petitionFields": {
                         petitioner,
                         petitions
                     }
                 })
-                shouldBlockNav.current = true;
             } else setPetitionNumber(n => n + 1);
         }
     }
@@ -229,14 +239,14 @@ export default function GeneratePage(props) {
     }
 
     function startNewPetition() {
-        shouldBlockNav.current = false;
-        history.push("/action");
-        shouldBlockNav.current = true;
+        setBlockNav(false);
+        setPetitions(initialPetitionState);
+        history.push("/");
     }
 
     return (
         <Form className="generator">
-            <NavBlock blockNav={shouldBlockNav} />
+            <NavBlock blockNav={blockNavRef} />
             <Petitioner {...petitioner} disabled={formDisabled} />
             <Petition petitionNumber={petitionNumber} disabled={formDisabled} />
             <Dockets petitionNumber={petitionNumber} disabled={formDisabled} />

--- a/frontend/src/src/components/GeneratePage/index.jsx
+++ b/frontend/src/src/components/GeneratePage/index.jsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useState } from "react";
-import { Link, useHistory } from 'react-router-dom';
+import React, { useEffect, useState, useRef } from "react";
+import { useHistory } from 'react-router-dom';
 import { Alert, Button, Col, Form, Row } from 'react-bootstrap';
 import Petitioner from "./components/Petitioner";
 import Petition from "./components/Petition";
@@ -13,6 +13,7 @@ import { useUser } from '../../context/user';
 import { initialPetitionState, usePetitions } from "../../context/petitions";
 import { usePetitioner, initialPetitionerState } from "../../context/petitioner";
 import { useIsMounted } from "../../hooks/useIsMounted";
+import NavBlock from "../util/navBlock";
 
 import "./style.css";
 import api from "../../services/api";
@@ -37,6 +38,7 @@ export default function GeneratePage(props) {
     const [busy, setBusy] = useState(false);
     const [downloadUrls, setDownloadUrls] = useState({0: ""});
     const [error, setError] = useState("");
+    let shouldBlockNav = useRef(true);
 
     const formDisabled = busy || success[petitionNumber];
     const totalPetitions = petitions.length;
@@ -197,12 +199,16 @@ export default function GeneratePage(props) {
             setError("");
             if (petitionNumber === totalPetitions - 1) {
                 // TODO: Should this info be saved to page history? delete if not
+
+                // Don't ask the user whether they want to navigate; just navigate
+                shouldBlockNav.current = false;
                 history.push("/review", {
                     "petitionFields": {
                         petitioner,
                         petitions
                     }
                 })
+                shouldBlockNav.current = true;
             } else setPetitionNumber(n => n + 1);
         }
     }
@@ -222,8 +228,15 @@ export default function GeneratePage(props) {
         return (<FallbackMessage/>);
     }
 
+    function startNewPetition() {
+        shouldBlockNav.current = false;
+        history.push("/action");
+        shouldBlockNav.current = true;
+    }
+
     return (
         <Form className="generator">
+            <NavBlock blockNav={shouldBlockNav} />
             <Petitioner {...petitioner} disabled={formDisabled} />
             <Petition petitionNumber={petitionNumber} disabled={formDisabled} />
             <Dockets petitionNumber={petitionNumber} disabled={formDisabled} />
@@ -269,10 +282,7 @@ export default function GeneratePage(props) {
                             <Button onClick={edit}>Edit Petition</Button>
                         </Col>
                         {(petitionNumber === totalPetitions - 1) && <Col>
-                            <Link to={{
-                                pathname: '/',
-                                state: {petitioner: petitioner}
-                            }}><Button>New Petition</Button></Link>
+                            <Button onClick={startNewPetition}>New Petition</Button>
                         </Col>}
                     </Form.Group>
                 </>

--- a/frontend/src/src/components/ReviewPage/index.jsx
+++ b/frontend/src/src/components/ReviewPage/index.jsx
@@ -8,6 +8,7 @@ import FallbackMessage from "../FallbackMessage";
 import { useUser } from '../../context/user';
 import { initialPetitionerState, usePetitioner } from "../../context/petitioner";
 import { initialPetitionState, usePetitions } from "../../context/petitions";
+import { useNavBlock } from "../../context/navBlockContext.jsx";
 import NavBlock from "../util/navBlock";
 import "./style.css";
 import api from "../../services/api";
@@ -39,9 +40,19 @@ export default function ReviewPage(props) {
     const { petitioner, setPetitioner } = usePetitioner();
     const { petitions, setPetitions } = usePetitions();
     const [ summary, setSummary ] = useState(initialSummary);
+    const { blockNavRef, setBlockNav } = useNavBlock();
     const getIsMounted = useIsMounted();
-    let shouldBlockNav = useRef(true);
-    
+
+    useEffect(() => {
+        // When this component mounts, turn on nav block
+        setBlockNav(true);
+
+        // cleanup on unmount
+        return () => {
+            setBlockNav(false);
+        };
+    }, [setBlockNav]);
+
     useEffect(() => {
         try {
             // re-create petitions state from history after page refresh
@@ -54,6 +65,7 @@ export default function ReviewPage(props) {
             window.scrollTo(0, 0)
         } catch {
             // TODO: proper error handling
+            setBlockNav(false);
             history.push("/");
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -89,9 +101,9 @@ export default function ReviewPage(props) {
     }, [petitioner, petitions])
 
     function startNewPetition() {
-        shouldBlockNav.current = false;
-        history.push("/action");
-        shouldBlockNav.current = true;
+        setBlockNav(false);
+        setPetitions(initialPetitionState);
+        history.push("/");
     }
 
     async function postGeneratorRequest(petitioner, petition, index) {
@@ -213,7 +225,7 @@ export default function ReviewPage(props) {
 
     return (
         <Container fluid className="pt-4">
-            <NavBlock blockNav={shouldBlockNav} />
+            <NavBlock blockNav={blockNavRef} />
             <Card className="mb-4 ">
                 <Card.Header as="h5" className="ps-3">Petitioner</Card.Header>
                 <ListGroup variant="flush">

--- a/frontend/src/src/components/ReviewPage/index.jsx
+++ b/frontend/src/src/components/ReviewPage/index.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useRef } from "react";
 import JSZip from "jszip";
 import { saveAs } from "file-saver";
 import { Button, Card, Container, ListGroup } from 'react-bootstrap';
@@ -8,6 +8,7 @@ import FallbackMessage from "../FallbackMessage";
 import { useUser } from '../../context/user';
 import { initialPetitionerState, usePetitioner } from "../../context/petitioner";
 import { initialPetitionState, usePetitions } from "../../context/petitions";
+import NavBlock from "../util/navBlock";
 import "./style.css";
 import api from "../../services/api";
 import { useAuth } from "../../context/auth";
@@ -39,6 +40,7 @@ export default function ReviewPage(props) {
     const { petitions, setPetitions } = usePetitions();
     const [ summary, setSummary ] = useState(initialSummary);
     const getIsMounted = useIsMounted();
+    let shouldBlockNav = useRef(true);
     
     useEffect(() => {
         try {
@@ -85,6 +87,12 @@ export default function ReviewPage(props) {
             petitionSummaries,
         })
     }, [petitioner, petitions])
+
+    function startNewPetition() {
+        shouldBlockNav.current = false;
+        history.push("/action");
+        shouldBlockNav.current = true;
+    }
 
     async function postGeneratorRequest(petitioner, petition, index) {
         let petitionFields = {
@@ -205,6 +213,7 @@ export default function ReviewPage(props) {
 
     return (
         <Container fluid className="pt-4">
+            <NavBlock blockNav={shouldBlockNav} />
             <Card className="mb-4 ">
                 <Card.Header as="h5" className="ps-3">Petitioner</Card.Header>
                 <ListGroup variant="flush">
@@ -214,7 +223,7 @@ export default function ReviewPage(props) {
             </Card>
             {petitionSummaries}
             <Button onClick={saveToZip} className="me-3 mb-3">Download All Petitions</Button>
-            <Button href="/" className="mb-3">Start New Petition</Button>
+            <Button onClick={startNewPetition} className="mb-3">Start New Petition</Button>
         </Container>
     )
 }

--- a/frontend/src/src/components/nav.jsx
+++ b/frontend/src/src/components/nav.jsx
@@ -1,15 +1,27 @@
 import React from 'react';
 import { Navbar, Nav, Container } from 'react-bootstrap';
+import { Link } from 'react-router-dom';
 import { useAuth } from '../context/auth';
 import { usePetitioner, initialPetitionerState } from '../context/petitioner';
 import { usePetitions, initialPetitionState } from '../context/petitions';
+import { useNavBlock } from "../context/navBlockContext.jsx";
 
 const Navigation = () => {
   const { logout, isAuthenticated } = useAuth();
   const { setPetitioner } = usePetitioner();
   const { setPetitions } = usePetitions();
+  const { blockNavRef, setBlockNav } = useNavBlock();
 
   const logOutAndReset = () => {
+    if (blockNavRef.current) {
+      const userConfirmed = window.confirm(
+        "You may have unsaved changes that will be lost. Are you sure you want to log out?"
+      );
+      if (!userConfirmed) {
+        return;
+      }
+    }
+    setBlockNav(false);
     setPetitioner(initialPetitionerState);
     setPetitions(initialPetitionState);
     logout("You have successfully logged out.");
@@ -25,7 +37,7 @@ const Navigation = () => {
       sticky="top"
     >
       <Container fluid>
-        <Navbar.Brand href="/">
+        <Navbar.Brand as={Link} to={"/"}>
           <img
             src="http://plsephilly.org/wp-content/uploads/2014/11/PLSE_logotype_320.png"
             width="90"
@@ -45,7 +57,7 @@ const Navigation = () => {
             ) : (
               <>
                 {/* <Nav.Link href="/signup">Sign up</Nav.Link> */}
-                <Nav.Link href="/login">Log in</Nav.Link>
+                <Nav.Link as={Link} to="/login">Log in</Nav.Link>
               </>
             )}
           </Nav>

--- a/frontend/src/src/components/util/navBlock.jsx
+++ b/frontend/src/src/components/util/navBlock.jsx
@@ -1,0 +1,39 @@
+import React, { useEffect } from 'react';
+import { useHistory } from 'react-router-dom';
+
+export default function NavBlock({blockNav}) {
+    const history = useHistory();
+
+    // If the user tries to reload the page, pop up a confirmation dialog
+    useEffect(() => {
+        const handleBeforeUnload = (event) => {
+            if (blockNav.current) {
+                event.preventDefault();
+                event.returnValue = '';
+            }
+        };
+
+        window.addEventListener('beforeunload', handleBeforeUnload);
+
+        return () => window.removeEventListener('beforeunload', handleBeforeUnload)
+    }, [blockNav, history])
+
+    // If the user tries to navigate from the /generate page to another page, pop up a confirmation dialog
+    useEffect(() => {
+        const unblock = history.block((location, action) => {
+            // console.log("location: ", location)
+            // console.log("action: ", action)
+            if (blockNav.current) {
+                if (location.pathname !== "/generate") {
+                    // console.log("action 2: ", action)
+                    return window.confirm('Changes to petitions may not be saved. Are you sure you want to leave?');
+                }
+            }
+            return true;
+        });
+
+        return () => unblock();
+    }, [blockNav, history])
+
+    return <></>;
+}

--- a/frontend/src/src/components/util/navBlock.jsx
+++ b/frontend/src/src/components/util/navBlock.jsx
@@ -1,13 +1,20 @@
 import React, { useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
+import { useAuth } from '../../context/auth';
 
+/**
+ * Renders no UI. Attaches event listeners to block navigation when active.
+ * This component is intended to be placed on pages with forms or unsaved data.
+ * @param {{ blockNav: React.MutableRefObject<boolean> }} props
+ */
 export default function NavBlock({blockNav}) {
     const history = useHistory();
+    const { isAuthenticated } = useAuth();
 
-    // If the user tries to reload the page, pop up a confirmation dialog
+    // If the user tries to reload or close the page, pop up a confirmation dialog
     useEffect(() => {
         const handleBeforeUnload = (event) => {
-            if (blockNav.current) {
+            if (blockNav.current && isAuthenticated) {
                 event.preventDefault();
                 event.returnValue = '';
             }
@@ -16,16 +23,15 @@ export default function NavBlock({blockNav}) {
         window.addEventListener('beforeunload', handleBeforeUnload);
 
         return () => window.removeEventListener('beforeunload', handleBeforeUnload)
-    }, [blockNav, history])
+    }, [blockNav, isAuthenticated])
 
-    // If the user tries to navigate from the /generate page to another page, pop up a confirmation dialog
+    // If the user tries to navigate away from a page where data could be lost using React Router, pop up a confirmation dialog
     useEffect(() => {
-        const unblock = history.block((location, action) => {
-            // console.log("location: ", location)
-            // console.log("action: ", action)
-            if (blockNav.current) {
-                if (location.pathname !== "/generate") {
-                    // console.log("action 2: ", action)
+        const unblock = history.block((destination) => {
+            if (blockNav.current && isAuthenticated) {
+                // It's safe to navigate between these paths
+                const safePaths = ['/upload', '/generate', '/review'];
+                if (!safePaths.includes(destination.pathname)) {
                     return window.confirm('Changes to petitions may not be saved. Are you sure you want to leave?');
                 }
             }
@@ -33,7 +39,7 @@ export default function NavBlock({blockNav}) {
         });
 
         return () => unblock();
-    }, [blockNav, history])
+    }, [blockNav, history, isAuthenticated])
 
     return <></>;
 }

--- a/frontend/src/src/context/navBlockContext.jsx
+++ b/frontend/src/src/context/navBlockContext.jsx
@@ -1,0 +1,23 @@
+import React, { createContext, useContext, useRef, useCallback } from 'react';
+
+const NavBlockContext = createContext();
+
+export function useNavBlock() {
+  return useContext(NavBlockContext);
+}
+
+export function NavBlockProvider({ children }) {
+  const blockNavRef = useRef(false);
+
+  const setBlockNav = useCallback((isBlocked) => {
+    blockNavRef.current = isBlocked;
+  }, []);
+
+  const value = { blockNavRef, setBlockNav };
+
+  return (
+    <NavBlockContext.Provider value={value}>
+      {children}
+    </NavBlockContext.Provider>
+  );
+}


### PR DESCRIPTION
## Overview

When the user tries to leave the Review or Generate page before saving changes, an alert is popped up.

### Does this close any currently open issues?

<!-- Change ### to #[number of issue], e.g. #1 -->
Closes #15

### Testing Instructions

Here are the cases I found to check:
- browser refresh
- browser tab close
- Log Out button clicked
- Home button in top left clicked
- Review Petitions button clicked
- for a multi-page petition:
  * Previous Petition
  * Save & Continue
  * Review Petitions

When the user tries to save or move on, an alert should not pop up.