### PR TITLE
Update repository name in links

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,5 +25,5 @@ Closes ###
 ### Before merging
 
 - [ ] PR has been reviewed and approved
-- [ ] All tests should pass, [testing instructions are here](https://github.com/Philadelphia-Lawyers-for-Social-Equity/docket_dashboard#testing).
-- [ ] Branch has been rebased on `develop` (or the branch being merged to). [See here for rebase instructions](https://github.com/Philadelphia-Lawyers-for-Social-Equity/docket_dashboard/blob/develop/CONTRIBUTING.md#reviewed-work)
+- [ ] All tests should pass, [testing instructions are here](https://github.com/Philadelphia-Lawyers-for-Social-Equity/PA_Expunger#testing).
+- [ ] Branch has been rebased on `develop` (or the branch being merged to). [See here for rebase instructions](https://github.com/Philadelphia-Lawyers-for-Social-Equity/PA_Expunger/blob/develop/CONTRIBUTING.md#reviewed-work)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ We also use issues for tracking our own team needs (e.g. adding documentation).
 
 ### Add an issue
 
-Navigate to our [issues page on Github](https://github.com/Philadelphia-Lawyers-for-Social-Equity/docket_dashboard/issues) and hit the big green `New` button.
+Navigate to our [issues page on Github](https://github.com/Philadelphia-Lawyers-for-Social-Equity/PA_Expunger/issues) and hit the big green `New` button.
 
 ### Types of issues
 
@@ -48,11 +48,11 @@ Clear context of why this new feature is needed and clear descriptions of what i
 
 ## Making code changes
 
-Changes to our codebase should always address an [issue](https://github.com/Philadelphia-Lawyers-for-Social-Equity/docket_dashboard/issues) and need to be requested to be merged by submitting a pull request that will be reviewed by at least the team lead or two other contributors.
+Changes to our codebase should always address an [issue](https://github.com/Philadelphia-Lawyers-for-Social-Equity/PA_Expunger/issues) and need to be requested to be merged by submitting a pull request that will be reviewed by at least the team lead or two other contributors.
 
 ### Choose an issue
 
-Look through the [issues page](https://github.com/Philadelphia-Lawyers-for-Social-Equity/docket_dashboard/issues) in the repo.
+Look through the [issues page](https://github.com/Philadelphia-Lawyers-for-Social-Equity/PA_Expunger/issues) in the repo.
 
 Find a task that has no current assignees and sounds like a task that either you can confidently take on yourself or involves a new language, framework, or design that you want learn.
 
@@ -104,7 +104,7 @@ git push
 
 In order to merge your work to the `develop` branch you must create a pull request.
 
-Often Github will put up a notification that a new branch has been pushed and give a green "Make a PR" button on any page of the repo. If you don't see this you can go to the [pull requests tab](https://github.com/Philadelphia-Lawyers-for-Social-Equity/docket_dashboard/pulls) and hit the big green `New` button.
+Often Github will put up a notification that a new branch has been pushed and give a green "Make a PR" button on any page of the repo. If you don't see this you can go to the [pull requests tab](https://github.com/Philadelphia-Lawyers-for-Social-Equity/PA_Expunger/pulls) and hit the big green `New` button.
 
 There is a template to follow to make sure that reviewers have enough context about the changes you made and what they fix.
 

--- a/platform/SETUP.md
+++ b/platform/SETUP.md
@@ -15,7 +15,7 @@ The _fastest_ route to a local install should be:
 1. Clone and enter this repository directory.
 
     ```
-    git clone git@github.com:Philadelphia-Lawyers-for-Social-Equity/docket_dashboard.git
+    git clone git@github.com:Philadelphia-Lawyers-for-Social-Equity/PA_Expunger.git
     ```
 
 1. Now we create git hooks that will allow us to track changes to .docx files. Run the following in your terminal:
@@ -85,7 +85,7 @@ The Frontend Portal allows users to sign up and associate their account with an 
 ## Settings
 
 Settings are controlled via environment variables, and can be reviewed in the
-[docker-compose.yml](https://github.com/Philadelphia-Lawyers-for-Social-Equity/docket_dashboard/blob/develop/docker-compose.yml) file:
+[docker-compose.yml](https://github.com/Philadelphia-Lawyers-for-Social-Equity/PA_Expunger/blob/develop/docker-compose.yml) file:
 
 - The primary admin username is `plse` and is not designed to change.
 - **EXPUNGER_PASS** controls the administrator password for user `plse`. Default is `defaultTestPassword`. It is set on the _first build,_ after which any changes must be made via the back-end.


### PR DESCRIPTION
## Overview

The old repository, docket_dashboard, was still referenced in some documentation. This PR replaces that with the current repo name.